### PR TITLE
Updating rocur documentation

### DIFF
--- a/content/rocur/about/index.en.md
+++ b/content/rocur/about/index.en.md
@@ -19,7 +19,7 @@ The **[R-Ladies RoCur (Rotating Curation)](https://twitter.com/WeAreRLadies)** i
   
 Every week, a different R-Lady takes over our twitter account to talk about the work they do in R. Featured curators come from a diversity of professions and have a range of experiences in R, from novice to expert.  
   
-If you are interested in becoming a curator, see our *Be a Curator* section (below) and [sign up here](https://goo.gl/forms/bQ7mHQDXrNHXEZCl2).  
+If you are interested in becoming a curator, see our *Be a Curator* section (below) and [sign up here](https://forms.gle/4Z6EMbDzRyFQsB6C8).  
   
 Check out [@WeAreRLadies](https://twitter.com/WeAreRLadies) every Monday for a new curator!    
   
@@ -29,9 +29,9 @@ Check out [@WeAreRLadies](https://twitter.com/WeAreRLadies) every Monday for a n
   
 ## Curator Schedule 
 
-**[current curator schedule](https://docs.google.com/spreadsheets/d/1pmphnR9EinGuAKbVqGzMIt6cWYmHNbeFVzaKJB59JdY/edit?usp=sharing)**  
+**[current curator schedule](https://docs.google.com/spreadsheets/d/13NwIphQ6o-3YJUbHtbDRf4texfMOCvhIDNZgDZhHv7U/edit?usp=sharing)**  
 
-**[Sign up to be a curator](https://goo.gl/forms/bQ7mHQDXrNHXEZCl2)** 
+**[Sign up to be a curator](https://forms.gle/4Z6EMbDzRyFQsB6C8)** 
   
 Please note: 
 * You will be asked to provide a first and second choice for week(s) you would like to curate.  
@@ -52,11 +52,11 @@ We are always looking for R-users to be a featured curator for our account! Ever
   
 ## Curator Procedures 
   
-:one: Sign up to be a curator via **[this form](https://goo.gl/forms/bQ7mHQDXrNHXEZCl2)**. You will be asked to provide a first and second choice for week(s) you would like to curate.       
+:one: Sign up to be a curator via **[this form](https://forms.gle/4Z6EMbDzRyFQsB6C8)**. You will be asked to provide a first and second choice for week(s) you would like to curate.       
   
 :two: Send a photo to `WeAre@rladies.org` that will be used as the profile pic of the account during your curation week.    
   
-:three: If your information has been received, the **[RoCur schedule](https://docs.google.com/spreadsheets/d/1pmphnR9EinGuAKbVqGzMIt6cWYmHNbeFVzaKJB59JdY/edit?usp=sharing)** will be updated to reflect the week you will be curating.    
+:three: If your information has been received, the **[RoCur schedule](https://docs.google.com/spreadsheets/d/13NwIphQ6o-3YJUbHtbDRf4texfMOCvhIDNZgDZhHv7U/edit?usp=sharing)** will be updated to reflect the week you will be curating.    
   
 :four: _*The week before you are scheduled to curate*_: Account administrators will send you an email with specific info about curating and show you the infographic that will be posted the Sunday before you curate. You’ll need to approve this infographic. You'll also need to read and agree to our [Curator Agreement](/rocur/guide/#curating-agreement).  
   

--- a/content/rocur/about/index.en.md
+++ b/content/rocur/about/index.en.md
@@ -45,10 +45,10 @@ Please note:
   
 We are always looking for R-users to be a featured curator for our account! Everyone is welcome; R-Ladies encourages R-users of all professional backgrounds and experience levels to curate this account. Additionally, individuals do not need to be affiliated with R-Ladies to curate. Featured curators must meet the following criteria:  
   
-* Curators must identify as [cis/trans women, trans men, non-binary, genderqueer, agender](/about/mission).  
+* Curators must identify as [cis/trans women, trans men, non-binary, genderqueer, agender](https://guide.rladies.org/rocur/about/).  
 * Curators do not need to be affiliated with R-Ladies; however, curators need to register in the [R-Ladies directory](https://rladies.org/directory/) if they haven’t yet.   
 * Curators must be individuals (i.e. an R-Ladies Chapter cannot be a featured curator; however, an organizer from a local chapter may curate and tweet about chapter events).   
-* By signing on to be a curator of @WeAreRLadies you agree to our Curator Agreement that is outlined in our [RoCur Curator Guide](/rocur/guide/).    
+* By signing on to be a curator of @WeAreRLadies you agree to our Curator Agreement that is outlined in our [RoCur Curator Guide](https://guide.rladies.org/rocur/guide/).    
   
 ## Curator Procedures 
   
@@ -58,7 +58,7 @@ We are always looking for R-users to be a featured curator for our account! Ever
   
 :three: If your information has been received, the **[RoCur schedule](https://docs.google.com/spreadsheets/d/13NwIphQ6o-3YJUbHtbDRf4texfMOCvhIDNZgDZhHv7U/edit?usp=sharing)** will be updated to reflect the week you will be curating.    
   
-:four: _*The week before you are scheduled to curate*_: Account administrators will send you an email with specific info about curating and show you the infographic that will be posted the Sunday before you curate. You’ll need to approve this infographic. You'll also need to read and agree to our [Curator Agreement](/rocur/guide/#curating-agreement).  
+:four: _*The week before you are scheduled to curate*_: Account administrators will send you an email with specific info about curating and show you the infographic that will be posted the Sunday before you curate. You’ll need to approve this infographic. You'll also need to read and agree to our [Curator Agreement](https://guide.rladies.org/rocur/guide/#curating-agreement).  
   
 :five: _*Saturday or Sunday before you curate*_: You will receive access to @WeAreRLadies via tweetdeck. The Twitter profile pic will be changed to your photo Sunday evening/Monday morning. Then you are ready to curate for the week!    
   

--- a/content/rocur/admin guide/index.en.md
+++ b/content/rocur/admin guide/index.en.md
@@ -7,7 +7,10 @@ weight: 60
 ## Account Admin  
 
 The account admin (team) for the rotating curator account are members of the R-Ladies community who keep [@WeAreRLadies](https://twitter.com/WeAreRLadies) running. The account admin could be a team of 1-4 people who can rotate responsibilities from month-to-month. Being an account admin is an opportunity to connect with R-Ladies from all over the world while facilitating an online community resource.     
-
+  
+*Please note this guide is a work in progress! We are currently working to build out this documentation. Thank you for your patience!*  
+  
+  
 ## Primary Responsibilities  
 
 The responsibilities of the account admin are to:  
@@ -55,18 +58,22 @@ The responsibilities of the account admin are to:
 
 
 ### Sunday before they are scheduled to curate:   
-* Post their final infographic to the RoCur feed (be sure to mention their personal Twitter handle).  
 * Add the curator’s Twitter handle as a contributor on the RoCur account (via Tweetdeck) and remove last week’s curator from the RoCur team. 
 * Email the curator that they are now added to the Twitter account.  
+* Post their final infographic to the RoCur feed (be sure to mention their personal Twitter handle).  
+   - Via Tweetdeck, we can schedule this post to go out on Sunday morning. The team aims to post this before [18h00 UTC](https://www.timebie.com/std/utc.php?q=18).  
+   - The tweet text should contain the Twitter handle of the curator and #RLadies hashtag (so that it can be retweeted by [@RLadiesGlobal](https://twitter.com/RLadiesGlobal). For example: "This week's #RLadies curator is **@[TWITTER HANDLE]**"  
+   - Alt Text: When uploading an image into Tweetdeck, a gray button will appear at the bottom of the image labelled "Add description." In the text field, we currently write:   
+   > Curator **[NAME]**, **[Role/Title]** at **[Organization]**. They say: "**[copy text about what they do in R]**"  
 * They will need to visit [tweetdeck.twitter.com](https://tweetdeck.twitter.com/) while logged into their twitter account in order to tweet from the account.  
 
-#### Same email ~1-2 days before the first day of curating
+#### Sample email ~1-2 days before the first day of curating
 
 >Hi NAME,
 >
 >We have added you as a contributor to the @WeAreRLadies account. While logged into twitter, visit: https://tweetdeck.twitter.com/ and you should see @WeAreRLadies under your “Accounts” (at the bottom left part of the menu). Twitter also has a [tweetdeck guide](https://help.twitter.com/en/using-twitter/how-to-use-tweetdeck) that might be useful.  
 >
->Please refer to our [Curator Guide](https://guide.rladies.org/rocur/guide/) for our curator agreement and tips re: engaging with our Twitter audience. Your curatorship will start on Monday, at 7AM ET and end on Saturday, at 12PM ET.  
+>Please refer to our [Curator Guide](https://guide.rladies.org/rocur/guide/) for our curator agreement and tips re: engaging with our Twitter audience. Your curatorship will start on Monday at [11h00 UTC](http://www.timebie.com/std/utc.php?q=11) and ends Saturday at [16h00 UTC](http://www.timebie.com/std/utc.php?q=16).
 >
 >If you have any questions or encounter any problem, you can send us an email at WeAre@rladies.org. Also, you can join our #rocur_twitter channel on the community slack where you can reach out to all RoCur Managers and get connected with past curators.  
 >  

--- a/content/rocur/admin guide/index.en.md
+++ b/content/rocur/admin guide/index.en.md
@@ -28,6 +28,7 @@ The responsibilities of the account admin are to:
 >Hi NAME,
 >
 >Thank you for the photo. You are scheduled to curate the week of DATE. We will contact you 1 week before you are scheduled to curate with more details. Let us know if you have any questions.   
+>
 >Thanks!
 
 

--- a/content/rocur/guide/index.en.md
+++ b/content/rocur/guide/index.en.md
@@ -7,7 +7,7 @@ weight: 10
 
 ## How Curating Works  
 
-* Curatorship begins each **Monday at 7:00 AM ET** and ends the following **Saturday at 12:00 PM ET**.   
+* Curatorship begins each **Monday at [11h00 UTC](http://www.timebie.com/std/utc.php?q=11)** and ends the following **Saturday at [16h00 UTC](http://www.timebie.com/std/utc.php?q=16)**.   
 * For the duration of the curatorship, the profile photo will be a photo of the curator. This is updated by the RoCur administrator.    
 * The personal twitter handle of the curator will be in the bio (if applicable, you do not need to be a twitter user prior to curating).   
 * Your first post should introduce yourself to the account followers. Your first tweet should tell the audience: what you do (your job, hobbies, etc.), and what you do in R.   
@@ -54,12 +54,7 @@ Please follow the [Twitter terms of service](https://help.twitter.com/en/rules-a
   
   
 ## Tweeting Tips  
-
-### Notes from a previous curator
-
-* [Curating for @WeAreRLadies on Twitter: From creating content to cultivating connections.](https://www.pipinghotdata.com/posts/2021-09-23-curating-for-wearerladies-on-twitter/) blog post by Shannon Pileggi, Sep 23, 2021.
-
-* [Be great and curate! Tips and outcomes from an `@WeAreRLadies` Twitter curator.](https://www.pipinghotdata.com/talks/2021-10-07-be-great-and-curate/) poster presentation by Shannon Pileggi, Oct 7, 2021.
+  
 
 ### Introducing Yourself  
   
@@ -147,3 +142,29 @@ Examples include:
 *	“My first introduction to XYZ was this blog post: URL”  
   
   
+  
+## Work from previous curators & the @WeAreRLadies team  
+  
+We are grateful all our previous curators who have worked hard to build our Twitter community. Many of them have also produced blogs, talks, and other resources on their curating experience. 
+  
+  
+### On curating for @WeAreRLadies
+  
+* [My Week with We Are R-Ladies](https://tolerancetoambiguity.com/my-week-with-we-are-r-ladies/): blog post by Divya Seernani, Feb 22, 2020.
+
+* [Curating for @WeAreRLadies on Twitter: From creating content to cultivating connections.](https://www.pipinghotdata.com/posts/2021-09-23-curating-for-wearerladies-on-twitter/): blog post by Shannon Pileggi, Sep 23, 2021.
+
+* [Be great and curate! Tips and outcomes from an `@WeAreRLadies` Twitter curator.](https://www.pipinghotdata.com/talks/2021-10-07-be-great-and-curate/): poster presentation by Shannon Pileggi, Oct 7, 2021.
+  
+  
+### Looking at data from @WeAreRLadies   
+  
+* Katherine Simeon's [lightning talk](https://www.youtube.com/watch?v=nzmkYUr0wS0) at rstudio::conf(2020) - Jan 30, 2020  
+  
+* Megan Stodel's blog post series looking at @WeAreRLadies data:
+  - [Analyzing Twitter Data](https://www.meganstodel.com/posts/analysing-twitter-data/) - Oct 24, 2020
+  - [Tweet Timing](https://www.meganstodel.com/posts/tweet-timing/) - Nov 2, 2020   
+  - [Hashtag Analyses](https://www.meganstodel.com/posts/hashtag/) - Nov 15, 2020  
+    
+    
+*If you have written any blog posts, given any talks, or analyzed any data in relation to @WeAreRLadies, please add your links via pull request!*  


### PR DESCRIPTION
I have made a couple changes to our rocur documentation:
* Changed the URLs for our [sign up form](https://forms.gle/4Z6EMbDzRyFQsB6C8) and [curator schedule](https://tinyurl.com/wearerladies-schedule).  
* Updated all times to be in UTC instead of ET.  
* Created a new section for work from previous curators and the @WeAreRLadies team to start a record of the blog posts, presentations, and other resources related to the rocur account.  
* Other typos/formatting changes. 