### PR TITLE
onboarding and removing organizers

### DIFF
--- a/content/organization/intro/co-organizers/index.en.md
+++ b/content/organization/intro/co-organizers/index.en.md
@@ -33,21 +33,31 @@ You can point people who hesitate to jump on board to the [intro chapter for org
 If some people are happy to help without committing, it's already a great progress for you.
 Remind them regularly they could become an official organizer. :wink:
 
-## How to onboard organizers?
+## How to onboard new organizers?
 
-* before a volunteer commits as an organizer, an idea might be to have them host (i.e. organize) one or a few meetups (be careful to acknowledge their work although they're not an official organizer (yet)!) --- see [Meetup docs about the "event organizer" role](https://help.meetup.com/hc/en-us/articles/360002879411-Managing-a-leadership-team);
+* Before a volunteer commits as an organizer, an idea might be to have them host (i.e. organize) one or a few meetups (be careful to acknowledge their work although they're not an official organizer (yet)!) --- see [Meetup docs about the "event organizer" role](https://help.meetup.com/hc/en-us/articles/360002879411-Managing-a-leadership-team);
 
-* after that, register them as organizers 
-  * on meetup and 
-  * [at the global level](https://github.com/rladies/rladiesguide/issues/18) (guidance in flux) to have them access your chapter email address; get invited to the organizers slack. 
-  * Locally, make sure to give them access to the needed tools/services e.g. Tweetdeck access to Twitter.
+* After that:
+  * Send new organizers the [R-Ladies Organizers form](https://rladies.org/form/organiser).
+  * Invite new organizes to the R-Ladies Community Slack.
+  * Update the chapter's information [on the website](https://github.com/rladies/rladies.github.io/tree/main/data/chapters).
+  
+* Also, register them as organizers 
+  * On meetup by requesting the new organizers to join their Meetup group as members, and changing their status to co-organizers on Meetup, and 
+  * [At the global level](https://github.com/rladies/rladiesguide/issues/18) (guidance in flux) to have them access your chapter email address; get invited to the organizers slack. 
+  * Locally, make sure to give them access to the needed tools/services e.g. X Pro (formerly TweetDeck) access to X (formerly Twitter).
   
 * Point them to this guide (and tell them any feedback is welcome).
+
+## How to remove retired chapter organizers?
+
+* Change status of co-organizers stepping down to members on Meetup.
+* Update the chapter's information [on the website](https://github.com/rladies/rladies.github.io/tree/main/data/chapters) by moving the current organizers to the "former organizers" field.
 
 ## How to organize team work?
 
 * You might assign roles to organizers e.g. one would be in charge of social media for instance;
-* Or task assignment can be more flexible. Organizers will probably volunteer to do things that play to their strenghts. You can have a rotation system for some tasks like Twitter and Meetup management.
+* Or task assignment can be more flexible. Organizers will probably volunteer to do things that play to their strenghts. You can have a rotation system for some tasks like Mastodon and Meetup management.
 
 Regarding Meetup roles, all organizers should have the [organizer role](https://help.meetup.com/hc/en-us/articles/360002879411-Managing-a-leadership-team) on Meetup.
 

--- a/content/organization/intro/co-organizers/index.en.md
+++ b/content/organization/intro/co-organizers/index.en.md
@@ -35,7 +35,7 @@ Remind them regularly they could become an official organizer. :wink:
 
 ## How to onboard new organizers?
 
-* The current organizers should contact the onboarding team at chapters@rladies.org, who will guide them through the process of onboarding new organizers and should share the email addresses of the new organizers.
+* The current organizers should contact the onboarding team at chapters@rladies.org. Please share the name and email address of each new organizer so that we can guide everyone through the onboarding process.
   
 * Before a volunteer commits as an organizer, an idea might be to have them host (i.e. organize) one or a few meetups (be careful to acknowledge their work although they're not an official organizer (yet)!) --- see [Meetup docs about the "event organizer" role](https://help.meetup.com/hc/en-us/articles/360002879411-Managing-a-leadership-team).
 

--- a/content/organization/intro/co-organizers/index.en.md
+++ b/content/organization/intro/co-organizers/index.en.md
@@ -46,7 +46,7 @@ Remind them regularly they could become an official organizer. :wink:
 ## How to organize team work?
 
 * You might assign roles to organizers e.g. one would be in charge of social media for instance;
-* Or task assignment can be more flexible. Organizers will probably volunteer to do things that play to their strenghts. You can have a rotation system for some tasks like Mastodon and Meetup management.
+* Or task assignment can be more flexible. Organizers will probably volunteer to do things that play to their strenghts. You can have a rotation system for some tasks like social media and Meetup management.
 
 Regarding Meetup roles, all organizers should have the [organizer role](https://help.meetup.com/hc/en-us/articles/360002879411-Managing-a-leadership-team) on Meetup.
 

--- a/content/organization/intro/co-organizers/index.en.md
+++ b/content/organization/intro/co-organizers/index.en.md
@@ -39,12 +39,11 @@ Remind them regularly they could become an official organizer. :wink:
 
 * After that:
   * Send new organizers the [R-Ladies Organizers form](https://rladies.org/form/organiser).
-  * Invite new organizes to the R-Ladies Community Slack.
-  * Update the chapter's information [on the website](https://github.com/rladies/rladies.github.io/tree/main/data/chapters).
-  
-* Also, register them as organizers 
-  * On meetup by requesting the new organizers to join their Meetup group as members, and changing their status to co-organizers on Meetup, and 
-  * [At the global level](https://github.com/rladies/rladiesguide/issues/18) (guidance in flux) to have them access your chapter email address; get invited to the organizers slack. 
+  * Invite the new organizers to the R-Ladies Community Slack. This workspace is our primary communication tool and a great place to discuss upcoming events, R-related topics, and more. Once they join, please encourage them to say hello and introduce themselves in the #welcome channel.
+  * Update the chapter's information [on the website](https://github.com/rladies/rladies.github.io/tree/main/data/chapters). If you're not comfortable editing the chapter's JSON file and submitting a new request, please email website@rladies.org.
+  * The new organizers will be invited to join the organizers' Slack workspace after they fill in the [R-Ladies Organizers form](https://rladies.org/form/organiser).
+  * Register them as organizers On Meetup by requesting the new organizers to join the existing Meetup group as members, and changing their status to co-organizers on Meetup.
+  * Email email@rladies.org with the new organizer's email address, so they can start receiving emails as well from the R-Ladies chapter's forwarding email address as well.
   * Locally, make sure to give them access to the needed tools/services e.g. X Pro (formerly TweetDeck) access to X (formerly Twitter).
   
 * Point them to this guide (and tell them any feedback is welcome).

--- a/content/organization/intro/co-organizers/index.en.md
+++ b/content/organization/intro/co-organizers/index.en.md
@@ -41,7 +41,7 @@ Remind them regularly they could become an official organizer. :wink:
 
 ## How to remove retired chapter organizers?
 
-* The current organizers should reach out to the onboarding team at chapters@rladies.org, who will guide them through the process of removing retired chapter organizers.
+* The current organizers should reach out to the onboarding team at chapters@rladies.org, who will guide them through the process retiring a former organizer.
 
 ## How to organize team work?
 

--- a/content/organization/intro/co-organizers/index.en.md
+++ b/content/organization/intro/co-organizers/index.en.md
@@ -35,23 +35,13 @@ Remind them regularly they could become an official organizer. :wink:
 
 ## How to onboard new organizers?
 
-* Before a volunteer commits as an organizer, an idea might be to have them host (i.e. organize) one or a few meetups (be careful to acknowledge their work although they're not an official organizer (yet)!) --- see [Meetup docs about the "event organizer" role](https://help.meetup.com/hc/en-us/articles/360002879411-Managing-a-leadership-team);
-
-* After that:
-  * Send new organizers the [R-Ladies Organizers form](https://rladies.org/form/organiser).
-  * Invite the new organizers to the R-Ladies Community Slack. This workspace is our primary communication tool and a great place to discuss upcoming events, R-related topics, and more. Once they join, please encourage them to say hello and introduce themselves in the #welcome channel.
-  * Update the chapter's information [on the website](https://github.com/rladies/rladies.github.io/tree/main/data/chapters). If you're not comfortable editing the chapter's JSON file and submitting a new request, please email website@rladies.org.
-  * The new organizers will be invited to join the organizers' Slack workspace after they fill in the [R-Ladies Organizers form](https://rladies.org/form/organiser).
-  * Register them as organizers On Meetup by requesting the new organizers to join the existing Meetup group as members, and changing their status to co-organizers on Meetup.
-  * Email email@rladies.org with the new organizer's email address, so they can start receiving emails as well from the R-Ladies chapter's forwarding email address as well.
-  * Locally, make sure to give them access to the needed tools/services e.g. X Pro (formerly TweetDeck) access to X (formerly Twitter).
+* The current organizers should contact the onboarding team at chapters@rladies.org, who will guide them through the process of onboarding new organizers and should share the email addresses of the new organizers.
   
-* Point them to this guide (and tell them any feedback is welcome).
+* Before a volunteer commits as an organizer, an idea might be to have them host (i.e. organize) one or a few meetups (be careful to acknowledge their work although they're not an official organizer (yet)!) --- see [Meetup docs about the "event organizer" role](https://help.meetup.com/hc/en-us/articles/360002879411-Managing-a-leadership-team).
 
 ## How to remove retired chapter organizers?
 
-* Change status of co-organizers stepping down to members on Meetup.
-* Update the chapter's information [on the website](https://github.com/rladies/rladies.github.io/tree/main/data/chapters) by moving the current organizers to the "former organizers" field.
+* The current organizers should reach out to the onboarding team at chapters@rladies.org, who will guide them through the process of removing retired chapter organizers.
 
 ## How to organize team work?
 


### PR DESCRIPTION
- Update the "How to onboard new organizers" section.
- Add the "How to remove retired chapter organizers" section.