### PR TITLE
Fix (some) links to blog.rladies.org

### DIFF
--- a/content/about/datacamp/index.en.md
+++ b/content/about/datacamp/index.en.md
@@ -9,9 +9,9 @@ We also do not promote the use of DataCamp or offer its products (even if they a
 
 For more context on the disapproval of DataCamp by the R-Ladies organization, please refer to the two statements on our blog.
 
-* [R-Ladies Global's disapproval of DataCamp](https://blog.rladies.org/post/statement-about-datacamp/)
+* [R-Ladies Global's disapproval of DataCamp](https://rladies.org/news/2019-04-08-statement-about-datacamp/)
 
-* [R-Ladies Global's response to the DataCamp Assessment Report](https://blog.rladies.org/post/datacamp-third-party-review/)
+* [R-Ladies Global's response to the DataCamp Assessment Report](https://rladies.org/news/2019-10-22-datacamp-third-party-review/)
 
 {{< tweet 1114507499728769024 >}}
 

--- a/content/comm/blog/index.en.md
+++ b/content/comm/blog/index.en.md
@@ -109,10 +109,10 @@ the post series of the 2018 IWD project. It shows in the posts list and in the
 post page.
 - **Tags**: Post tags. They should include meaningful information; for recurrent
 posts please follow previous tags. 4 or 5 tags is a good number.
-[Tags](http://blog.rladies.org/tags/).
+[Tags](https://rladies.org/tags/).
 - **Categories**: Post categories. Like tags but the theme is more general. This
 field is currently not visible and is optional.
-[Categories](http://blog.rladies.org/categories/).
+[Categories](https://rladies.org/categories/).
 
 All of the information will be shown in the post yaml, and can also be edited later.
 

--- a/content/comm/iwd/index.en.md
+++ b/content/comm/iwd/index.en.md
@@ -16,9 +16,9 @@ The goals of this chapter is to document our previous efforts for folks who migh
 
 ## Information about previous campaigns
 
-* [Behind the scenes of R-Ladies IWD2018 Twitter action!](https://blog.rladies.org/post/ideation_and_creation/) -- tweets featuring all R-Ladies from the R-Ladies directory. Take-home message: sign up in our directory.
+* [Behind the scenes of R-Ladies IWD2018 Twitter action!](https://rladies.org/blog/conclusion/) -- tweets featuring all R-Ladies from the R-Ladies directory. Take-home message: sign up in our directory.
 
-* [IWD 2019 Twitter Action](https://blog.rladies.org/post/blog_iwdtwitter_2019/) -- tweets featuring all R-Ladies chapters. In Spanish [Acción de Twitter para el IWD 2019](https://blog.rladies.org/post/blog_iwdtwitter_2019_es/). Take-home message: how to create an R-Ladies chapter.
+* [IWD 2019 Twitter Action](https://rladies.org/blog/2019-03-25-blog_iwdtwitter_2019/) -- tweets featuring all R-Ladies chapters. Take-home message: how to create an R-Ladies chapter.
 
 * IWD 2020 had [tweets featuring R-Ladies lessons](https://github.com/rladies/IWD#catalog-the-meetup-material-in-github-from-the-chapters-and-tweet-this-material-during-the-campaign). [Shiny app](https://yabellini.shinyapps.io/RLadiesLesson/). Take-home message: share and re-use (depending on the licence) materials from R-Ladies meetups.
 

--- a/content/organization/events/speakers/index.en.md
+++ b/content/organization/events/speakers/index.en.md
@@ -27,7 +27,7 @@ weight: 53
 
 * Remember the [rules about Prioritization of Underrepresented/Minority Genders](/about/mission/#r-ladies-rules--guidelines).
 
-* In line with R-Ladies’ Mission Statement and with our [Black Lives Matter Statement](https://blog.rladies.org/post/2020-06-06-blm/) 
+* In line with R-Ladies’ Mission Statement and with our [Black Lives Matter Statement](https://rladies.org/news/2020-06-06-blm/) 
 to achieve participation and representation in our events of generally excluded groups, taking into account the intersectionality of gender, race, language and geography; for these reasons we request:
 
   - In chapter events, invite speakers of diverse race, language and geography (i.e., avoid a one year period with all white speakers at the chapter events).


### PR DESCRIPTION
I just noted that the links to blog.rladies.org don't work anymore.

I updated some of them which were easily findable, but the following links are still broken:

```
$ grep -Rnw . -e "blog.rladies.org"
```

```
./content/organization/events/speakers/index.en.md:30:* In line with R-Ladies’ Mission Statement and with our [Black Lives Matter Statement](https://blog.rladies.org/post/2020-06-06-blm/) 
./content/organization/events/general/index.en.md:83:* [Spanish metameetup](https://blog.rladies.org/post/spanishmetameetup/).
./content/comm/blog/index.en.md:112:[Tags](http://blog.rladies.org/tags/).
./content/comm/blog/index.en.md:115:[Categories](http://blog.rladies.org/categories/).
```