### PR TITLE
remove embedded tweets that prevent guide build

### DIFF
--- a/content/about/datacamp/index.en.md
+++ b/content/about/datacamp/index.en.md
@@ -13,8 +13,6 @@ For more context on the disapproval of DataCamp by the R-Ladies organization, pl
 
 * [R-Ladies Global's response to the DataCamp Assessment Report](https://rladies.org/news/2019-10-22-datacamp-third-party-review/)
 
-{{< tweet 1114507499728769024 >}}
-
 {{% notice tip %}}
 [Suggestion of alternative learning resources](/organization/resources/learning-r/).
 {{% /notice %}}

--- a/content/comm/abstract-review/index.en.md
+++ b/content/comm/abstract-review/index.en.md
@@ -16,11 +16,10 @@ R-Ladies Global has a system for review and feedback of conference abstracts and
 
 ### Promotion
 
-The system can be promoted once in a while, in particular before big conference deadlines, 
+The system can be promoted on R-Ladies social media once in a while, 
+in particular before big conference deadlines, 
 
-* By R-Ladies Global Twitter account
-
-{{< tweet 1072767166934671360 >}}
+* By R-Ladies social media
 
 * In the [organizers slack](/organization/tech/accounts/#slack)
 

--- a/content/organization/events/online/index.en.md
+++ b/content/organization/events/online/index.en.md
@@ -206,10 +206,6 @@ Outside of Zoom you could try out platforms such as [gather.town](https://gather
 
 ### General best practice
 
-* A thread by Angela Li
-
-{{< tweet 1238481908633423873 >}}
-
 * ["Virtual Meetups" LinkedIn post by Noa Tamir](https://www.linkedin.com/pulse/virtual-meetups-noa-tamir/)
 
 * [The Carpentries guide for online teaching](https://carpentries.org/blog/2020/03/tips-for-teaching-online/)
@@ -224,7 +220,6 @@ Outside of Zoom you could try out platforms such as [gather.town](https://gather
 
 ### Accessibility best practice
 
-{{< tweet 1299296290266849281 >}}
 
 * [How to organize and run an awesome deaf accessible virtual event?](https://hearmeoutcc.com/deaf-accessible-virtual-events/)
 

--- a/content/organization/events/promotion/index.en.md
+++ b/content/organization/events/promotion/index.en.md
@@ -23,7 +23,6 @@ Making an event inclusive can mean to be explicit about things you thought might
 
 * Make graphics for social media? You could use [canva](https://canva.com/), [OmniGraffle](https://www.omnigroup.com/omnigraffle/) on Mac, slides templates (Google slides or Microsoft Powerpoint) saved as PNG, [a Shiny app to design hex logos](https://connect.thinkr.fr/hexmake/). Example below. In any case make sure to add an alternative text to the image on social media, and to make the text of your tweet informative, as well as to add a link to the event on Meetup.
 
-{{< tweet 1299834952578674689 >}}
 
 * Put presentations or links to them in your chapter's [GitHub repo](/organization/tech/accounts/#github)[^iwd]. Read [Carpe talk](https://www.tidyverse.org/blog/2018/07/carpe-talk/) by Jenny Bryan and Mara Averick.
 

--- a/content/organization/intro/co-organizers/index.en.md
+++ b/content/organization/intro/co-organizers/index.en.md
@@ -23,8 +23,6 @@ Sometimes, though, folks need more encouragement.
 
 * Maybe you will randomly meet your co-organizers at a conference! (when in-person events are a thing again, or in the break-out rooms of an online conference)
 
-{{< tweet 963861899040477200 >}}
-
 * In all cases try to think of how to diversify your team. (We welcome tips!) It might come with diversifying who attends the meetups, by promoting events in different places than usual?
 
 

--- a/content/organization/intro/thanks/index.en.md
+++ b/content/organization/intro/thanks/index.en.md
@@ -13,5 +13,3 @@ Thank you cards could be sent once a year like R-Ladies Philadelphia does
 ("we try not to splurge, but try to add a sticker or other small token of appreciation as well when possible"),
 by snail mail, or more regularly by email.
 Remind recipients on why you are thanking them, especially if it has been a while since they helped or collaborated with you.
-
-{{< tweet 1082488324282109952 >}}


### PR DESCRIPTION
Other PRs were failing because of embedded tweets. I have removed all embedded tweets so that build of the guide website can resume.