### PR TITLE
The R-Ladies RoCur landing page.

### DIFF
--- a/content/rocur/_index.en.md
+++ b/content/rocur/_index.en.md
@@ -7,4 +7,4 @@ menuTitle: WeAreRLadies
 ---
 
   
-The **[R-Ladies RoCur (Rotating Curation)](https://twitter.com/WeAreRLadies)** is a twitter handle that will feature an awesome R-Lady each week. This account is run by R-Ladies Global.      
+The **[R-Ladies RoCur (Rotating Curation)](https://bsky.app/profile/weare.rladies.org)** is a social media handle that will feature an awesome R-Lady each week. This account is run by R-Ladies Global.      

--- a/content/rocur/_index.en.md
+++ b/content/rocur/_index.en.md
@@ -7,4 +7,4 @@ menuTitle: WeAreRLadies
 ---
 
   
-The **[R-Ladies RoCur (Rotating Curation)](https://bsky.app/profile/weare.rladies.org)** is a social media handle that will feature an awesome R-Lady each week. This account is run by R-Ladies Global.      
+The **[R-Ladies RoCur (Rotating Curation)](https://bsky.app/profile/weare.rladies.org)** is a social media handle that features an awesome R-Lady each week. This account is run by R-Ladies Global.      


### PR DESCRIPTION
Changes to the R-Ladies RoCur details page from the Twitter handle to a general description to a social media handle.