### PR TITLE
Document Jinx, the org's GitHub App

### DIFF
--- a/content/global-team/jinx/_index.en.md
+++ b/content/global-team/jinx/_index.en.md
@@ -41,6 +41,19 @@ In issues, Jinx responds to slash commands typed by maintainers — the kind you
 In the background, Jinx runs scheduled jobs: weekly chapter reports, Airtable syncs, stale-entry reminders, contributor lists.
 And in a handful of workflows, Jinx steps across repositories — for example, when the directory repo needs to trigger a preview build in `rladies.github.io`, that cross-repo handshake goes through Jinx.
 
+## Where Jinx runs today
+
+The org is gradually migrating workflows off personal access tokens and onto Jinx.
+Repos already on Jinx:
+
+- [`rladies/jinx`](https://github.com/rladies/jinx) — the app's own home, where most of the scheduled and command-driven workflows live.  
+- [`rladies/global-team`](https://github.com/rladies/global-team) — onboarding, offboarding, stale-issue reminders, status reports.  
+- [`rladies/rladies.github.io`](https://github.com/rladies/rladies.github.io) — preview builds, blog merge automation, contributor welcomes.  
+- [`rladies/directory`](https://github.com/rladies/directory) — preview-build dispatch when entries change.  
+- [`rladies/awesome-rladies-blogs`](https://github.com/rladies/awesome-rladies-blogs) — blog index automation.  
+
+If you maintain a repo not on this list and find yourself reaching for a personal access token, that is a good signal to consider Jinx instead.
+
 ## Talking to Jinx with slash commands
 
 In any repo where Jinx is installed, you can leave a comment on an issue or pull request that starts with `/jinx`.

--- a/content/global-team/jinx/_index.en.md
+++ b/content/global-team/jinx/_index.en.md
@@ -1,0 +1,144 @@
+---
+title: "Jinx"
+linkTitle: "Jinx"
+weight: 5
+chapter: false
+aliases:
+  - /coordination/jinx/
+---
+
+Someone opens a pull request in the directory repo.
+Within seconds, a website preview build kicks off in `rladies.github.io`, a comment appears on the PR with a link to follow the build, and the contributor sees a friendly note welcoming them.
+None of that needed a person.
+It needed Jinx.
+
+Jinx is the R-Ladies organization's GitHub App.
+Think of it as a small bot account that lives in the org and lends its identity to our automations.
+When a workflow needs to comment on a pull request, kick off a build in another repository, or invite a new contributor to a team, it asks Jinx for a short-lived token and acts on Jinx's behalf.
+The comment shows up as coming from `jinx-familiar[bot]`.
+The bot is the familiar — the little creature that does the errands so the witches don't have to.
+
+## Why we use a bot instead of personal tokens
+
+For a long time R-Ladies workflows ran on personal access tokens.
+That worked, but it had two annoying properties.
+First, those tokens belong to one person.
+When the person leaves, takes a long break, or simply forgets to rotate, the tokens expire and a workflow somewhere goes quiet — usually at the worst possible moment.
+Second, personal tokens tend to drift toward broad scopes: it is easier to grant "all my repos" than to scope down per-workflow, and what starts as a quick fix becomes a key with far more reach than it needs.
+
+A GitHub App fixes both.
+Jinx has no human owner.
+The credentials live as org-level secrets, not in any individual's account.
+Each workflow run mints a token that expires in an hour and is scoped to the specific repos that workflow needs to touch.
+Nothing long-lived sits around waiting to leak.
+
+## What you'll see Jinx doing
+
+Across the R-Ladies repos, Jinx shows up in a few shapes.
+
+In pull request comments, Jinx posts build notifications, contributor welcomes, and review checklists.
+In issues, Jinx responds to slash commands typed by maintainers — the kind you might recognize from other bots like `/lgtm` or `/approve`.
+In the background, Jinx runs scheduled jobs: weekly chapter reports, Airtable syncs, stale-entry reminders, contributor lists.
+And in a handful of workflows, Jinx steps across repositories — for example, when the directory repo needs to trigger a preview build in `rladies.github.io`, that cross-repo handshake goes through Jinx.
+
+## Talking to Jinx with slash commands
+
+In any repo where Jinx is installed, you can leave a comment on an issue or pull request that starts with `/jinx`.
+The bot reads the comment, runs the matching workflow, and replies inline.
+
+A few of the commands that exist today:
+
+`/jinx invite @username to <team>` — onboards a new global team volunteer to a specific working group.  
+`/jinx offboard @username from <team>` — the reverse, when someone is rotating off.  
+`/jinx announce <post-url>` — drops a blog post into the announcements queue.  
+`/jinx events <chapter-slug>` — pulls upcoming events for a chapter.  
+`/jinx events sync` — refreshes the Meetup/Luma event mirror.  
+`/jinx report weekly` — generates the weekly activity digest.  
+`/jinx help` — lists what Jinx currently knows how to do.  
+
+The canonical list lives in the [jinx package commands source](https://github.com/rladies/jinx/blob/main/R/commands.R).
+If a command you expect is not in the help output, the workflow it points to may need to be installed in the repo you are working in.
+
+## Under the hood
+
+A workflow that wants to act as Jinx follows the same three-step pattern every time.
+
+First, it mints an installation token using the [actions/create-github-app-token](https://github.com/actions/create-github-app-token) action, passing in the Jinx App ID and private key.
+Second, it scopes that token to just the repositories the workflow needs to touch — `directory,rladies.github.io`, for example, and not the whole org.
+Third, it uses the token wherever it would otherwise have used `GITHUB_TOKEN` or a personal access token.
+
+The whole thing looks like this:
+
+```yaml
+- name: Mint Jinx app token
+  id: app_token
+  uses: actions/create-github-app-token@v1
+  with:
+    app-id: ${{ secrets.JINX_APP_ID }}
+    private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+    owner: rladies
+    repositories: directory,rladies.github.io
+
+- name: Comment on the PR
+  env:
+    GH_TOKEN: ${{ steps.app_token.outputs.token }}
+  run: gh pr comment ${{ github.event.pull_request.number }} --body "Hi from Jinx"
+```
+
+The token returned by the first step is good for one hour.
+Once the workflow finishes, the token is revoked and can never be reused.
+
+## What Jinx is allowed to touch
+
+Jinx asks for the minimum set of permissions it needs across the org, no more.
+The current grants are:
+
+| Scope | Permission | What it enables |
+|---|---|---|
+| Repository | Issues — read & write | PR/issue comments, slash command replies |
+| Repository | Pull Requests — read & write | PR comments, reviews, status |
+| Repository | Contents — read | Reading files for reports and checks |
+| Repository | Actions — read & write | Cross-repo `gh workflow run` dispatch |
+| Organization | Members — read & write | `/jinx invite` and `/jinx offboard` |
+| Organization | Administration — read | Reading team membership |
+
+If a new workflow needs a permission outside this list, the cleanest path is to ask the org admins to expand Jinx rather than introduce a parallel token.
+A single bot identity is easier to audit and rotate than several.
+
+## Adding Jinx to a new workflow
+
+Adopting Jinx in a repo it is already installed on is short:
+
+1. Confirm Jinx is installed on the repo by checking [the org's app settings](https://github.com/organizations/rladies/settings/installations) — the jinx entry should list your repository.  
+2. Confirm `JINX_APP_ID` and `JINX_PRIVATE_KEY` are available as org-level secrets that your repo can read.  
+3. Add the `actions/create-github-app-token` step to your workflow, scope it with the `repositories:` field, and use `steps.app_token.outputs.token` wherever you would have used a token.  
+
+If Jinx is _not_ yet installed on the repo you need, ping someone with org-admin access — the install is a click in the GitHub UI.
+
+## When something breaks
+
+A few failure modes that have actually happened, and what they mean.
+
+> Failed to create token: Invalid keyData
+
+The private key in `JINX_PRIVATE_KEY` is not a valid PEM.
+Almost always this means the contents were truncated when pasted into the secret, or the `-----BEGIN RSA PRIVATE KEY-----` / `-----END RSA PRIVATE KEY-----` headers were accidentally left out, or a client secret was pasted instead of a private key.
+Regenerate the key from the app settings, copy the entire `.pem` file contents including headers and newlines, and re-paste.
+GitHub Apps support multiple active private keys, so you can roll a new one without taking the old one down until you have confirmed the new one works.
+
+> Resource not accessible by integration
+
+The token was minted, but the action it tried to perform is outside Jinx's permission set on the target repo.
+Either Jinx is not installed on the target, or the permission needed is not yet granted to the app.
+Check the app installation list and the permission table above.
+
+> Bad credentials
+
+The App ID is wrong, or the private key does not match the App ID.
+This shows up most often when there are two Apps in the org and the wrong pair of secrets is being used together.
+
+## A note on the name
+
+The bot account is `jinx-familiar` — Jinx the app, familiar the role.
+Familiars carry messages, fetch ingredients, and generally handle the small magic so the witches can focus on the big magic.
+That is roughly what we want the bot to do for us, too.

--- a/content/global-team/jinx/_index.en.md
+++ b/content/global-team/jinx/_index.en.md
@@ -12,7 +12,7 @@ Within seconds, a website preview build kicks off in `rladies.github.io`, a comm
 None of that needed a person.
 It needed Jinx.
 
-Jinx is the R-Ladies organization's GitHub App.
+Jinx is the RLadies+ organization's GitHub App.
 Think of it as a small bot account that lives in the org and lends its identity to our automations.
 When a workflow needs to comment on a pull request, kick off a build in another repository, or invite a new contributor to a team, it asks Jinx for a short-lived token and acts on Jinx's behalf.
 The comment shows up as coming from `jinx-familiar[bot]`.
@@ -20,7 +20,7 @@ The bot is the familiar — the little creature that does the errands so the wit
 
 ## Why we use a bot instead of personal tokens
 
-For a long time R-Ladies workflows ran on personal access tokens.
+For a long time RLadies+ workflows ran on personal access tokens.
 That worked, but it had two annoying properties.
 First, those tokens belong to one person.
 When the person leaves, takes a long break, or simply forgets to rotate, the tokens expire and a workflow somewhere goes quiet — usually at the worst possible moment.
@@ -34,7 +34,7 @@ Nothing long-lived sits around waiting to leak.
 
 ## What you'll see Jinx doing
 
-Across the R-Ladies repos, Jinx shows up in a few shapes.
+Across the RLadies+ repos, Jinx shows up in a few shapes.
 
 In pull request comments, Jinx posts build notifications, contributor welcomes, and review checklists.
 In issues, Jinx responds to slash commands typed by maintainers — the kind you might recognize from other bots like `/lgtm` or `/approve`.


### PR DESCRIPTION
## Summary
Adds a new Global Team section documenting Jinx, the R-Ladies GitHub App that backs cross-repo automation across the org. The page covers what Jinx is, what you'll see it doing, the slash commands available to maintainers, the installation-token pattern workflows use, the permission set Jinx holds, the repos currently using Jinx, how to adopt it in a new workflow, and the failure modes that have actually happened.

## Why now
The org is in the middle of migrating workflows off personal access tokens onto Jinx — `rladies/jinx`, `rladies/global-team`, `rladies/rladies.github.io`, `rladies/directory`, and `rladies/awesome-rladies-blogs` are all moving over. The docs don't yet explain what Jinx is, what permissions it has, or how to add it to a new workflow. Landing these docs first gives the workflow PRs a canonical reference to point at.

## Where it lives
[`content/global-team/jinx/_index.en.md`](content/global-team/jinx/_index.en.md), weight 5 — near the top of the Global Team section since most tooling guides will end up linking back here.

## Test plan
- [ ] `hugo server` locally and confirm the page renders under `/global-team/jinx/`
- [ ] Confirm internal links resolve (org install settings, jinx repo commands.R, actions/create-github-app-token, repo links in the new "where Jinx runs today" section)
- [ ] Eyeball the troubleshooting section against the real failure messages we saw during the migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)