### PR TITLE
Use Jinx app token for all automated actions

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -10,24 +10,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout your repository
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # Set up Git user
       - name: Configure Git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Jinx[bot]"
+          git config user.email "jinx@rladies.org"
 
-      # Create a tag for the release
       - name: Create Tag
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           RELEASE="$(date +"%Y").$(date +"%m")"
           echo "RELEASE=$RELEASE" >> $GITHUB_ENV
           git tag -a "$RELEASE" -m "Automatic release $RELEASE"
           git push origin "$RELEASE"
 
-      # Create a GitHub Release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -35,4 +42,4 @@ jobs:
           name: "Automatic Release ${{ env.RELEASE }}"
           body: "Quarterly release of the R-Ladies guide."
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/greet-remind.yaml
+++ b/.github/workflows/greet-remind.yaml
@@ -9,13 +9,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Checkout repo
         uses: actions/checkout@v4
 
       - uses: actions/github-script@v7
         name: "Greet new contributor"
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
               const fs = require('fs');
               const PR_AUTHOR = context.payload.pull_request.user.login;

--- a/.github/workflows/render_acknowledgements.yaml
+++ b/.github/workflows/render_acknowledgements.yaml
@@ -9,6 +9,14 @@ jobs:
   render-acknowledgements:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Checkout repo
         uses: actions/checkout@v4
 
@@ -19,8 +27,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Jinx[bot]"
+          git config user.email "jinx@rladies.org"
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
@@ -30,7 +38,7 @@ jobs:
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tinytex: true
 
@@ -46,7 +54,7 @@ jobs:
 
       - name: Commit and Push
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git add content/acknowledgements/
           git commit -m "Automated commit by GitHub Actions"  || echo "Nothing to commit"	


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with Jinx app token in greet-remind, render_acknowledgements, and auto-release workflows
- Welcome comments, acknowledgement commits, and quarterly releases now appear as `Jinx[bot]`

## Test plan
- [ ] Open a PR and verify the welcome comment is from Jinx[bot]
- [ ] Trigger render_acknowledgements and verify commit is by Jinx[bot]
- [ ] Verify auto-release creates tags/releases as Jinx[bot]

🤖 Generated with [Claude Code](https://claude.com/claude-code)