### PR TITLE
Adopt jinx reusable for contributor welcome

### DIFF
--- a/.github/workflows/greet-remind.yaml
+++ b/.github/workflows/greet-remind.yaml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   welcome:
     uses: rladies/jinx/.github/workflows/reusable-welcome-contributor.yml@main

--- a/.github/workflows/greet-remind.yaml
+++ b/.github/workflows/greet-remind.yaml
@@ -3,80 +3,17 @@ name: Greet New Contributor
 on:
   pull_request:
     types: [opened]
+  issues:
+    types: [opened]
 
 jobs:
-  greet-and-remind:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.JINX_APP_ID }}
-          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
-          owner: rladies
-
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - uses: actions/github-script@v7
-        name: "Greet new contributor"
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-              const fs = require('fs');
-              const PR_AUTHOR = context.payload.pull_request.user.login;
-
-              // Check if user has any previous commits via GitHub API
-              const { data: commits } = await github.rest.repos.listCommits({
-                owner: 'rladies',
-                repo: 'rladiesguide',
-                author: PR_AUTHOR,
-                per_page: 1
-              }).catch(() => ({ data: [] }));
-
-              if (commits.length > 0) {
-                console.log(`${PR_AUTHOR} has previous commits, not a new contributor`);
-                return;
-              }
-
-              // Check if user has any previous merged PRs
-              const { data: prs } = await github.rest.pulls.list({
-                owner: 'rladies',
-                repo: 'rladiesguide',
-                state: 'closed',
-                per_page: 100
-              });
-              const hasMergedPR = prs.some(pr =>
-                pr.user.login === PR_AUTHOR &&
-                pr.merged_at &&
-                pr.number !== context.payload.pull_request.number
-              );
-
-              if (hasMergedPR) {
-                console.log(`${PR_AUTHOR} has previous merged PRs, not a new contributor`);
-                return;
-              }
-
-              // Check if user is already in .zenodo.json
-              const zenodo = JSON.parse(fs.readFileSync('.zenodo.json', 'utf8'));
-              const creators = zenodo.creators || [];
-              const nameLC = PR_AUTHOR.toLowerCase();
-              const inZenodo = creators.some(c => {
-                const name = (c.name || '').toLowerCase();
-                return name.includes(nameLC) || nameLC.includes(name.split(',')[0].trim().toLowerCase());
-              });
-
-              if (inZenodo) {
-                console.log(`${PR_AUTHOR} found in .zenodo.json, not a new contributor`);
-                return;
-              }
-
-              console.log(`${PR_AUTHOR} is a new contributor, posting welcome comment`);
-              await github.rest.issues.createComment({
-                issue_number: context.payload.pull_request.number,
-                owner: 'rladies',
-                repo: 'rladiesguide',
-                body: `Welcome ${PR_AUTHOR}! It looks like this is your first contribution to this repository. 🎉\n\nPlease remember to add yourself to the [.zenodo.json](.zenodo.json).`
-              });
+  welcome:
+    uses: rladies/jinx/.github/workflows/reusable-welcome-contributor.yml@main
+    with:
+      extra_message: |
+        While you are here, please remember to add yourself to the
+        [`.zenodo.json`](.zenodo.json) file so you are credited in the
+        next release.
+    secrets:
+      JINX_APP_ID: ${{ secrets.JINX_APP_ID }}
+      JINX_PRIVATE_KEY: ${{ secrets.JINX_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Replaces 75 lines of bespoke first-time-contributor detection plus a hardcoded welcome string with a 15-line caller that delegates to the [rladies/jinx](https://github.com/rladies/jinx) reusable.

The \`.zenodo.json\` reminder isn't lost — it goes through the reusable's new \`extra_message\` input, so contributors still get the project-specific nudge in the same comment. Just driven from a single canonical place from now on.

## Depends on

- [rladies/jinx#60](https://github.com/rladies/jinx/pull/60) which adds the \`extra_message\` input to \`reusable-welcome-contributor.yml\`. The caller here references \`@main\`, so #60 (and its base #58) need to land in jinx before this workflow will pick up the new input. Merging this PR before that is harmless — the job would just post the standard welcome without the zenodo reminder until the reusable catches up.

## Notes

- Same \`JINX_APP_ID\` / \`JINX_PRIVATE_KEY\` secrets the existing workflow already uses.
- Also picks up issue-opened welcomes (the old workflow was PR-only) — minor scope expansion that matches the rest of the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)