### PR TITLE
Emit article date meta tags on non-page content

### DIFF
--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -19,6 +19,21 @@
   {{- end }}
 {{- end }}
 
+{{/*
+  Relearn's opengraph.html only emits article:published_time / article:modified_time
+  when .IsPage is true. Fill the gap on the home page, section indexes, and taxonomies
+  so the Jinx RAG indexer can weight every page by content age and maintenance freshness.
+*/}}
+{{- if not .IsPage }}
+  {{- $iso8601 := "2006-01-02T15:04:05-07:00" }}
+  {{- with or .PublishDate .Date }}
+    <meta property="article:published_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }}>
+  {{- end }}
+  {{- with .Lastmod }}
+    <meta property="article:modified_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }}>
+  {{- end }}
+{{- end }}
+
 {{ if .IsHome }}
 <script type="application/ld+json">
 {


### PR DESCRIPTION
## Summary

- Relearn's [`opengraph.html`](https://github.com/McShelby/hugo-theme-relearn/blob/main/layouts/partials/opengraph.html) gates `article:published_time` and `article:modified_time` on `.IsPage`, so the home page, section indexes, and taxonomies were leaving these tags off entirely.
- Add a fallback block in [layouts/partials/custom-header.html](layouts/partials/custom-header.html) that emits both tags when `.IsPage` is false, so every URL in the sitemap exposes its `.Date` and git-derived `.Lastmod`.
- Regular pages are untouched — they keep relearn's native emission (which also adds `article:section` and `article:tag`).

## Why

The Jinx RAG indexer reads these tags to weight chunks by both content age and maintenance freshness (`enableGitInfo: true` is already on, so `.Lastmod` reflects the last git touch). Without dates on section indexes and the home page, those chunks landed in the vector index with no temporal signal.

Custom-header approach avoids forking the upstream `opengraph.html` partial — minimal-touch and survives relearn updates.

## Verification

Built locally and confirmed:
- `/` (home): `<meta property="article:modified_time" content="2025-06-03T13:15:37+02:00">` ✓
- `/organizers/` (section index): `<meta property="article:modified_time" content="2026-05-09T18:07:48+02:00">` ✓
- `/global-team/` (section index): `<meta property="article:modified_time" content="2026-05-09T18:07:48+02:00">` ✓
- `/organizers/intro/get-started/` (regular page): unchanged — relearn-native tags still emitted ✓

Companion changes:
- rladies/jinx#63 — reranker-side change that consumes this signal.
- rladies/rladies.github.io#593 — matching change for the main website.