### PR TITLE
Document the GitHub organisation in Global Team infrastructure

### DIFF
--- a/content/global-team/infrastructure/github/_index.en.md
+++ b/content/global-team/infrastructure/github/_index.en.md
@@ -1,0 +1,58 @@
+---
+title: "GitHub Organisation"
+linkTitle: "GitHub"
+weight: 80
+chapter: false
+---
+
+The `rladies` organisation on GitHub hosts every public artefact the project ships — the website, the chapter directory, the blog feed, this guide, the bot, the branding files.
+It runs on the **GitHub Team** plan, paid for through a leadership member's faculty account, with no SSO and a small group of leadership owners.
+This subsection documents how the org itself is wired together: who has which role, what the core repos do, how `main` is protected, and which apps and bots are installed.
+
+If the faculty billing relationship behind the Team plan ever lapses — the account holder leaves, the institution withdraws the perk, the card on file fails — the org drops to the Free plan.
+Private repos in the org would become read-only until billing is restored or someone takes over the plan from another faculty or sponsor account.
+The shortest path back is to either restore billing on the same account or transfer the plan to a different faculty account holder, both of which are done from `github.com/organizations/rladies/billing`.
+This is the single largest single-point-of-failure in the org's day-to-day operations, which is part of the open Team-vs-Free-for-OSS question below.
+
+The individual credentials those workflows depend on each have their own runbook — see [GitHub PAT]({{% relref "../github-pat" %}}), [Admin Token]({{% relref "../github-admin-token" %}}), and [SSH Deploy Keys]({{% relref "../ssh-deploy-keys" %}}).
+This section is about the layer above those secrets: the org configuration that makes them necessary in the first place.
+
+## What this section covers
+
+- [Organisation membership]({{% relref "org-membership" %}}) — owners, teams, member invites, offboarding.
+- [Core repositories]({{% relref "core-repositories" %}}) — the eight or so repos that matter for day-to-day operations.
+- [Branch protection and merge policy]({{% relref "branch-protection" %}}) — what `main` enforces and how automation works around it.
+- [Apps and bots]({{% relref "apps-and-bots" %}}) — Jinx, Dependabot, and the deliberately short list of installed integrations.
+
+## A note on credentials
+
+RLadies+ is part-way through a slow migration from personal access tokens to a GitHub App.
+[Jinx]({{% relref "/global-team/jinx" %}}) is the App, and new workflows mint short-lived installation tokens through it.
+The older workflows still ride on two PATs (`GLOBAL_GHA_PAT` and `ADMIN_TOKEN`) and three SSH deploy keys, all of which are tied to a personal GitHub account.
+That's progress, not a finished migration.
+Every time someone touches a workflow that still uses a PAT, the right question to ask is whether Jinx could do the job instead.
+
+## Open decision: stay on Team or apply for Free for OSS?
+
+The org currently pays for **GitHub Team** through a faculty account.
+GitHub also runs a [Free for OSS Organizations](https://docs.github.com/en/billing/managing-the-plan-for-your-github-account/free-for-open-source-organizations) programme that gives nonprofit open source projects most Team-tier features at no cost.
+RLadies+ plausibly qualifies — the org is a nonprofit, the work is community-driven, and the codebases are public — but applying means an extra review process and surrendering the Team plan's billing relationship in exchange for the upgraded one.
+
+The tradeoffs as we understand them:
+
+- **Staying on Team** keeps the current billing arrangement and avoids a procurement detour.
+  The cost is real, but it is already absorbed through the faculty account.
+  The plan is stable and the feature set is what we already use.
+- **Applying for Free for OSS** removes the dependence on one person's faculty billing relationship — which is its own quiet single-point-of-failure — and frees up whatever budget would otherwise go to GitHub.
+  The downsides are application overhead, possible scrutiny of nonprofit eligibility, and a non-zero risk of being downgraded later if GitHub changes the programme rules.
+
+This is an open question for leadership.
+This page lays out the shape of the decision; it does not make a recommendation.
+
+## Cadence
+
+Org-owner and admin lists should be reviewed every 6 to 12 months — who has owner, who has admin, who has left the project.
+Most of this work is already automated through `global-team` onboarding and offboarding workflows (cross-linked from [Org membership]({{% relref "org-membership" %}})), but the human review is what catches the cases the workflows miss.
+The literal checklist for that review lives in [Org membership — Review cadence]({{% relref "org-membership#review-cadence" %}}).
+
+TODO: confirm the current cadence in practice and which leadership role owns running the review.

--- a/content/global-team/infrastructure/github/apps-and-bots.md
+++ b/content/global-team/infrastructure/github/apps-and-bots.md
@@ -1,0 +1,86 @@
+---
+title: "Apps and bots"
+linkTitle: "Apps & bots"
+weight: 40
+---
+
+The list of GitHub Apps installed on the `rladies` org is short on purpose.
+Every installed app gets some level of access to repository contents, issues, or org metadata, and each one is something that has to be reviewed when org owners change.
+The fewer apps in the list, the easier the review.
+
+To see what is currently installed, open `github.com/organizations/rladies/settings/installations` (or **Settings → Third-party Access → GitHub Apps** from the org page).
+Only org owners can view this page.
+
+## Jinx
+
+The headline integration is [Jinx]({{% relref "/global-team/jinx" %}}) — the GitHub App that backs the org's automation.
+Workflows that need to comment on PRs, dispatch builds across repos, invite new members, or push commits as a bot identity mint short-lived installation tokens through Jinx instead of using a personal access token.
+
+Jinx is installed on the repos listed in ["Where Jinx runs today"]({{% relref "/global-team/jinx#where-jinx-runs-today" %}}).
+The App's permission set, the secrets it needs, and the pattern for adopting it in a new workflow are in [For developers]({{% relref "/global-team/jinx/for-developers" %}}).
+
+Adding Jinx to a new repo is the recommended path whenever a workflow would otherwise reach for `GLOBAL_GHA_PAT` or `ADMIN_TOKEN`.
+The org-level Jinx secrets (`JINX_APP_ID`, `JINX_PRIVATE_KEY`) are already available to every repo in the org — see [Jinx for developers]({{% relref "/global-team/jinx/for-developers" %}}) for the full secret inventory and the App permissions Jinx already holds.
+
+Adopting Jinx in a new workflow looks like this:
+
+```yaml
+jobs:
+  do-the-thing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get a Jinx installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
+      - name: Use it
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr comment $PR_NUMBER --body "hello from Jinx"
+```
+
+Two details that catch people out: the input is `client-id`, not `app-id`, and the token is only valid for one hour after the step runs.
+If the new workflow needs a permission Jinx doesn't yet hold on the target repo (Discussions, Pages, anything outside the table in [Jinx for developers]({{% relref "/global-team/jinx/for-developers#what-jinx-is-allowed-to-touch" %}})), ask an org admin to expand Jinx rather than spin up a parallel token.
+
+If Jinx is accidentally uninstalled from a repo, every workflow on that repo that mints an installation token will start failing with `Resource not accessible by integration`.
+The fix is to re-install: open `github.com/organizations/rladies/settings/installations`, click **Configure** next to Jinx, and add the repo back to the "Repository access" list.
+The org-level secrets stay put — only the installation grant needs restoring.
+
+## Dependabot
+
+Dependabot is GitHub-native and likely active across the core repos for security alerts and version updates, although configuration is per-repo rather than org-wide.
+Where it is enabled, it opens PRs against `main` like any other contributor and goes through the same branch-protection review (see [Branch protection]({{% relref "branch-protection" %}})).
+
+To check or change the org-wide defaults, go to `github.com/organizations/rladies/settings/security_analysis` (**Settings → Code security** from the org page).
+Per-repo configuration lives in `.github/dependabot.yml` on each repo.
+
+When a Dependabot PR can't merge — usually because branch protection requires an approving review and no human got to it — the fix is one of: a human reviewer approves and merges it manually, or `dependabot.yml` is updated to assign the PR to a real reviewer so the notification surfaces.
+Disabling branch protection to let Dependabot through is not a fix.
+
+TODO: confirm Dependabot is enabled on each of the core repos and whether any repo has a checked-in `dependabot.yml` worth promoting to a template.
+
+## Other integrations
+
+The deliberately short list of additional integrations:
+
+- **GitHub Actions** — not really an "app" in the same sense, but worth naming: every workflow in the org runs through Actions, which means org-level Actions settings (allowed actions, runner permissions, secret access scope) are part of this surface area.
+  Review at `github.com/organizations/rladies/settings/actions` (**Settings → Actions → General** from the org page).
+  TODO: confirm the current "Allowed actions" policy and whether it restricts third-party actions or permits any reusable workflow.
+- **Netlify** — connected to `rladies.github.io` for preview builds and to `rladiesguide` for the guide site.
+  The OAuth grant lives at the user level, not as an org-installed app, but it shows up in the deploy chain.
+  See [Build Architecture]({{% relref "../build-architecture" %}}) for how preview deploys reach Netlify.
+
+## What's not installed
+
+A short list of things that are _not_ on the org and which should stay off without a clear reason:
+
+- No third-party code review or security-scanning apps with write access.
+- No CI services beyond GitHub Actions.
+- No bots from individual contributor accounts with org-wide install scope.
+
+Keeping this list small is the whole point.
+Anything added here should be reviewable at a glance by the next person who inherits org-owner duties.

--- a/content/global-team/infrastructure/github/branch-protection.md
+++ b/content/global-team/infrastructure/github/branch-protection.md
@@ -1,0 +1,73 @@
+---
+title: "Branch protection and merge policy"
+linkTitle: "Branch protection"
+weight: 30
+---
+
+A protected `main` is the cheapest insurance policy a small org has against accidental damage.
+On the core RLadies+ repos, `main` is protected: changes go through pull requests, pull requests need a review, force-pushes are off, and direct commits to `main` are blocked.
+The convention applies to `rladies.github.io`, `directory`, `awesome-rladies-blogs`, `global-team`, `jinx`, and `rladiesguide`.
+
+TODO: walk each of the six core repos at `github.com/<repo>/settings/rules` and record the exact ruleset configuration here — what the convention describes below is the working assumption, but the source of truth is the GitHub Settings UI, and the two have drifted before.
+
+## What the convention covers
+
+For the core repos, the working assumption is:
+
+- **All changes via PR.** Direct pushes to `main` are blocked.
+- **At least one approving review** before merge.
+  On smaller repos this is often the same person approving and merging from a different role; the structural requirement still adds a deliberate pause.
+- **Required status checks.** Where a repo has CI (build, lint, link-check, structure-check), those checks must pass.
+- **No force-pushes** to `main`.
+- **Admin bypass** is enabled — without it, the scheduled and dispatched workflows below could not push at all.
+
+This setup costs almost nothing in day-to-day friction and catches the obvious classes of mistake: rebasing onto the wrong branch, pushing a half-finished commit, an automated process running away.
+
+## Setting it up on a repo
+
+To set up or modify branch protection on a repo:
+
+1. Open the repo on github.com.
+2. Click **Settings** in the top tab bar (only visible to repo admins).
+3. In the left sidebar, click **Rules → Rulesets** under "Code and automation".
+4. Click **New ruleset → New branch ruleset** (or **Edit** on the existing `main` ruleset if one is already in place).
+5. Set "Target branches" to `Include default branch`, then enable the rules listed in [What the convention covers](#what-the-convention-covers) above under "Branch rules".
+6. Under "Bypass list", add the leadership team (or specific owners) if scheduled workflows running under one of their PATs need to push to `main` — see [Where automation has to bypass](#where-automation-has-to-bypass).
+7. Set "Enforcement status" to **Active** and save.
+
+The ruleset is per-repo, so the same configuration needs applying to each core repo individually.
+There is no org-wide branch-protection template on GitHub at the time of writing — the closest substitute is documenting the convention here and reviewing it on each repo during the [periodic membership audit]({{% relref "org-membership#review-cadence" %}}).
+
+GitHub still supports the older "Branch protection rules" UI under **Settings → Branches**.
+New rules should use rulesets; the older UI is being phased out and is left in place only for repos whose protection predates rulesets.
+
+## Where automation has to bypass
+
+A handful of workflows legitimately push to `main` without going through a PR.
+This is where the cost of branch protection shows up: every one of these flows needs an identity with bypass permission, and the credentials for that identity are the most sensitive secrets in the org.
+
+The two known bypass identities, both documented in their own runbooks:
+
+- [`ADMIN_TOKEN`]({{% relref "../github-admin-token" %}}) — used by `global-team.yml` on `rladies.github.io` to push the Airtable-sourced Global Team data straight to `main`, and by `merge-pending.yaml` to auto-merge scheduled blog posts.
+- `push-to-protected` SSH deploy key — used by the same `global-team.yml` workflow on its push step; see [SSH Deploy Keys]({{% relref "../ssh-deploy-keys" %}}).
+
+The reason these workflows bypass protection rather than open a PR is mostly cadence.
+A 12-hour scheduled sync of team data doesn't gain much from a human review step — there's no human watching at 3am to approve it.
+A scheduled blog merge whose only job is to flip a date-gated PR from "pending" to "merged" is similarly mechanical.
+
+When the bypass identity goes away — the PAT expires, the SSH key is revoked, the person who created the PAT leaves the org — the symptom is the same in both cases: the scheduled workflow fails at the push step with `protected branch` or `permission denied`.
+The fix is to rotate the credential (see the linked runbooks) and, if necessary, re-add the new identity to the ruleset's bypass list at `github.com/<repo>/settings/rules`.
+
+## Why this is operational debt, honestly
+
+Every workflow that bypasses branch protection is a workflow that depends on a high-privilege secret.
+That secret has to be rotated, scoped tightly, and audited periodically.
+Two such secrets is a manageable number.
+Five would not be.
+
+Where possible, new workflows that need to land changes on `main` should open a PR and let [Jinx]({{% relref "/global-team/jinx" %}}) auto-approve or auto-merge it under the App's identity rather than mint a token with bypass.
+That keeps the "who can write to `main` outside of review" list short.
+
+## Settings review
+
+When walking the org owner / admin review (see [Org membership]({{% relref "org-membership" %}})), also check the branch protection rules on the core repos for drift — particularly that admin bypass hasn't been silently extended to other workflows, and that no new "Allow specified actors to bypass" entries have crept in.

--- a/content/global-team/infrastructure/github/core-repositories.md
+++ b/content/global-team/infrastructure/github/core-repositories.md
@@ -1,0 +1,78 @@
+---
+title: "Core repositories"
+linkTitle: "Core repos"
+weight: 20
+---
+
+The `rladies` org hosts dozens of repositories — chapter presentation archives, one-off workshop materials, retired experiments.
+A much smaller set runs the project day to day.
+If any one of these stops working, something visible to the community breaks.
+This page is the short list, with one paragraph per repo and a pointer to wherever it is documented in detail.
+
+The full repo list is at `github.com/orgs/rladies/repositories`; the eight below are the ones to know about first.
+
+## The eight that matter
+
+### `rladies.github.io`
+
+The website at `rladies.org` — Hugo source, build workflows, and the deployment pipeline that pulls together the chapter directory, blog feed, and Global Team data.
+This is the most interconnected repo in the org: it clones two other private repos via SSH on every build, dispatches workflows in those repos, and posts comments back when builds finish.
+For the full topology, see [Build Architecture]({{% relref "../build-architecture" %}}).
+
+### `directory`
+
+The chapter directory data source.
+Airtable submissions flow in, a workflow turns them into a PR, and merging the PR triggers a preview build on `rladies.github.io`.
+The interaction with the website is documented in [Build Architecture]({{% relref "../build-architecture" %}}); the PAT it uses to dispatch is in [GitHub PAT]({{% relref "../github-pat" %}}).
+
+### `awesome-rladies-blogs`
+
+The blog post feed.
+Contributors open PRs adding their blog URL; on merge, the website rebuilds and the post appears on the community blog page.
+Same cross-repo dispatch pattern as `directory` — see [Build Architecture]({{% relref "../build-architecture" %}}).
+
+### `global-team`
+
+Onboarding and offboarding automation for new chapter organisers and Global Team members.
+The workflows here are the entry point for "add this person to the right teams" and "remove this person cleanly" — they use the [Admin Token]({{% relref "../github-admin-token" %}}) for the org-admin operations and are triggered by the human flow described in [Onboarding new chapter organizers]({{% relref "/global-team/onboarding" %}}).
+
+### `meetup_archive`
+
+A scheduled archive of chapter and event data pulled from the Meetup.com API every 12 hours.
+The full `events.json` produced here feeds both chapter activity reporting and the [Jinx]({{% relref "/global-team/jinx" %}}) content indexer.
+Secret management lives in [Meetup API]({{% relref "../meetup-api" %}}).
+
+### `jinx`
+
+The R package, Cloudflare Worker, content indexer, and workflow definitions that together make up the [Jinx]({{% relref "/global-team/jinx" %}}) bot.
+This is the home of the GitHub App and the long-term destination for any workflow that currently uses a personal access token.
+The architecture, permissions, and adoption guide live in the Jinx section — see [For developers]({{% relref "/global-team/jinx/for-developers" %}}).
+
+### `branding-materials`
+
+The visual identity files — logos, hex sheets, the Affinity and Canva source files, the `brand.yml` for Quarto and Shiny, and the [Branding-guidelines.pdf](https://github.com/rladies/branding-materials/blob/main/Branding-guidelines.pdf).
+Most chapter and Global Team branding questions resolve to a file in this repo.
+See the [Branding]({{% relref "/branding" %}}) section for which file to grab when.
+
+### `rladiesguide`
+
+This guide.
+A Hugo site hosted on Netlify at `guide.rladies.org`, deployed via a webhook stored as `RLADIESGUIDE` on the org `.github` repo (see [Build Architecture]({{% relref "../build-architecture" %}})).
+PR-time checks run a Hugo build (`check-build.yaml`), a broken-link sweep (`link-check.yaml`), i18n coverage (`i18n-check.yaml`), and Zenodo metadata validation.
+Quarterly releases, contributor greetings, and acknowledgements are handled by [Jinx]({{% relref "/global-team/jinx" %}}).
+
+## Repos that are core-adjacent
+
+A few more repos appear regularly in the workflow logs without quite belonging on the "if it breaks, the community notices" list:
+
+- `awesome-rladies-creations` — content and package issue automation, Slack RSS feed for community-made R artefacts.
+- `meetupr` — the R client library for the Meetup API, used by `meetup_archive` and documented in [Meetup API]({{% relref "../meetup-api" %}}).
+- `.github` — the org-level config repo; holds the `RLADIESGUIDE` Netlify deploy hook secret and any org-wide community health files.
+
+If you maintain one of these and find yourself adding a new workflow or a new secret, document it in the appropriate runbook so the next person doesn't have to reverse-engineer it from the workflow YAML.
+
+## What's deliberately not in this section
+
+Repos belonging to individual chapters (`meetup-presentations_*`, location-specific workshop repos) are not part of the org's operational infrastructure.
+They're the org's _content_, not its plumbing.
+The plumbing is the eight repos above.

--- a/content/global-team/infrastructure/github/org-membership.md
+++ b/content/global-team/infrastructure/github/org-membership.md
@@ -1,0 +1,85 @@
+---
+title: "Organisation membership"
+linkTitle: "Org membership"
+weight: 10
+---
+
+The `rladies` GitHub org follows a familiar nonprofit pattern: a small group of leadership members hold the **Owner** role, a larger group of contributors hold **Member**, and almost everything sensitive is gated behind team membership rather than direct role checks.
+There is no SSO, no SCIM, no enterprise tier — just the standard Team-plan member list and the org's own teams.
+
+To run any of the admin actions on this page you need the **Owner** role on the `rladies` org.
+Member is not enough — Members can't see the people list with role filters, can't invite or remove anyone, and can't view the audit log.
+A handful of `gh` commands below assume the [GitHub CLI](https://cli.github.com/) is installed and authenticated as your Owner account (`gh auth status` will tell you which account is active).
+
+## Roles
+
+- **Owners** — full admin on every repo, can change org settings, can manage billing, can invite or remove anyone.
+  The convention is that leadership members hold this role, mirroring how leadership has admin access in 1Password and Google Workspace.
+  TODO: list current GitHub org owners.
+- **Members** — regular contributors, scoped by team membership.
+  A Member's effective permissions on any given repo come from the teams they belong to, not from their org role.
+- **Outside collaborators** — kept to a minimum.
+  Where they exist, they should be on a specific repo for a specific reason, with a note in the relevant runbook.
+
+The runbooks elsewhere in this section refer in places to "someone on the leadership team with org-owner permissions" without naming names — that's deliberate.
+The owner list changes with leadership terms and shouldn't be hardcoded into every page that depends on it.
+
+To see who currently holds which role, open `github.com/orgs/rladies/people` and filter by **Role → Owner** (or **Member**, **Outside collaborator**).
+The page also shows two-factor status, last activity, and team membership at a glance — useful when running the [Review cadence](#review-cadence) below.
+
+## Teams
+
+The org uses GitHub teams to grant repo permissions in batches rather than per-person.
+At least one team is referenced from the existing runbooks: `rladies/global`, which the [`GLOBAL_GHA_PAT`]({{% relref "../github-pat" %}}) uses for membership lookups in `hello.yaml` on `rladies.github.io`.
+Other teams exist for chapter onboarding routing, Meetup management, and the website team — these are referenced indirectly by the email templates and onboarding instructions.
+TODO: list current teams and what each one controls.
+
+The full team list lives at `github.com/orgs/rladies/teams`.
+Click into a team to see its members, the repos it grants access to, and any nested child teams.
+From the command line with `gh` authenticated, `gh api orgs/rladies/teams --paginate` returns the same list as JSON — handy for diffing membership over time.
+
+When a workflow needs to check "does this person belong to RLadies+?", the check should go through a team membership lookup, not a hard-coded username list.
+
+## Invitations
+
+New members are invited through the `global-team` repo's onboarding workflows, which use the [`ADMIN_TOKEN`]({{% relref "../github-admin-token" %}}) to act on the org:
+
+- `onboarding-01-invite.yml` sends the GitHub org invitation.
+- `onboarding-02-check-invite.yml` polls to see whether the invited person accepted.
+- `onboarding-03-create-issue.yml` opens a tracking issue and assigns the new member to the right teams.
+
+The trigger for all three is the chapter onboarding flow described in [Onboarding new chapter organizers]({{% relref "/global-team/onboarding" %}}).
+
+## Offboarding
+
+When someone leaves leadership or a chapter goes dormant, the [`global-team`](https://github.com/rladies/global-team) repo's `offboarding-finalise.yml` workflow removes them from the org teams.
+That workflow uses [`GLOBAL_GHA_PAT`]({{% relref "../github-pat" %}}) — `admin:org` is one of the scopes that PAT carries.
+
+What the automation does _not_ do:
+
+- Revoke owner-level access — owners must be demoted to Member before offboarding.
+  To demote: open `github.com/orgs/rladies/people`, find the person, click the `⋯` menu next to their name, choose **Change role**, select **Member**, and confirm.
+  The offboarding workflow can then remove them like any other member.
+- Rotate PATs or SSH keys that the departing person personally created.
+  If the person was the account behind [`GLOBAL_GHA_PAT`]({{% relref "../github-pat" %}}) or [`ADMIN_TOKEN`]({{% relref "../github-admin-token" %}}), those tokens need rotating immediately — see the linked runbooks for the rotation steps.
+  The [SSH deploy keys]({{% relref "../ssh-deploy-keys" %}}) are not tied to a personal account, so they don't need touching when a person leaves — only when a key itself expires or leaks.
+- Remove the person from chapter-level resources that live outside GitHub (Slack, Meetup, email).
+  Those have their own offboarding paths.
+- Remove them as an outside collaborator on any repo where they were added directly.
+  To check, open `github.com/orgs/rladies/outside-collaborators` and remove any entry for the departing person.
+
+## Review cadence
+
+Every 6 to 12 months, walk through the owner list and the team membership of every team that grants repo-write or org-admin permissions.
+
+Concretely, that means opening four pages in order:
+
+1. `github.com/orgs/rladies/people?role=owner` — is everyone on this list still active and still in a role that needs Owner?
+2. `github.com/orgs/rladies/teams` — for each team that grants write access, is every member still active?
+3. `github.com/orgs/rladies/people/pending_invitations` — any invitations more than a few months old probably won't be accepted; revoke them.
+4. `github.com/organizations/rladies/settings/audit-log` — scan the last few months for unexpected `org.add_member`, `team.add_member`, or `repo.access` events.
+   Anything that doesn't have an obvious owner gets followed up.
+
+Also check the branch protection rulesets on the core repos for drift while you're here — see [Branch protection settings review]({{% relref "branch-protection#settings-review" %}}).
+
+TODO: confirm who owns this review and how often it runs in practice.


### PR DESCRIPTION
## Summary

Adds a new `content/global-team/infrastructure/github/` subsection documenting the `rladies` GitHub organisation itself — the layer above the individual PAT, admin token, and SSH key runbooks.

Five new pages:

- `_index.en.md` — section overview, plan/SSO/ownership posture, and the open question on whether to apply for GitHub Free for OSS.
- `org-membership.md` — owners, teams, invite flow (cross-links the `global-team` onboarding workflows), offboarding flow.
- `core-repositories.md` — eight core repos (`rladies.github.io`, `directory`, `awesome-rladies-blogs`, `global-team`, `meetup_archive`, `jinx`, `branding-materials`, `rladiesguide`) with one paragraph each and cross-links to their detailed docs.
- `branch-protection.md` — the `main`-protection convention and why the two bypass identities (`ADMIN_TOKEN`, `push-to-protected`) exist.
- `apps-and-bots.md` — Jinx as the headline (cross-linked, not duplicated), Dependabot, and a deliberately short list of other integrations.

Stacks on top of #207 (`split-tech-organisers-vs-infra`).

The Free-for-OSS question is framed honestly with tradeoffs on both sides rather than as a recommendation — that's a leadership call. Several `TODO:` markers are left for facts that need confirmation against the live org settings (current owner names, the team list, Dependabot coverage, exact branch protection rules).

No existing files were touched. Hugo will auto-list the new subsection on the infrastructure index.

## Test plan

- [ ] `hugo` builds cleanly with the theme submodule initialised (this worktree's submodule was empty so the build couldn't be verified locally — please confirm in a normal checkout).
- [ ] Cross-references resolve: `../build-architecture`, `../github-pat`, `../github-admin-token`, `../ssh-deploy-keys`, `../meetup-api`, `/global-team/jinx`, `/global-team/jinx/for-developers`, `/global-team/onboarding`, `/branding`.
- [ ] The new section appears in the Infrastructure sidebar under `weight: 80`.
- [ ] Replace `TODO:` markers with confirmed details from the live org (or leave them as follow-ups).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>