### PR TITLE
Document Google Workspace in Global Team infrastructure

### DIFF
--- a/content/global-team/infrastructure/google-workspace/_index.en.md
+++ b/content/global-team/infrastructure/google-workspace/_index.en.md
@@ -1,0 +1,43 @@
+---
+title: "Google Workspace"
+linkTitle: "Google Workspace"
+weight: 70
+chapter: false
+---
+
+Every RLadies+ chapter has an email address ending in `@rladies.org`, and every one of those mailboxes lives in a single Google Workspace tenant.
+The tenant runs on the [Google for Nonprofits](https://www.google.com/nonprofits/) programme on the Workspace Nonprofit plan, with `rladies.org` as the only domain we manage.
+
+## What we actually use
+
+In practice, we use Workspace for two things: email and the occasional shared document.
+Email is the load-bearing piece — chapter mailboxes (`yourcity@rladies.org`) plus personal aliases (`yourname@rladies.org`) for leadership and Global Team members issued since March 2019.
+A handful of Global Team meeting notes live in Drive.
+Everything else Workspace offers — Chat, Meet, Sites, Vault — is essentially untouched at the Global Team level.
+
+That is intentional rather than accidental.
+Every surface we don't use is a surface we don't have to secure, train new volunteers on, or migrate when policies change.
+The smaller our footprint, the less drama when an organiser rotates off the team.
+
+## Who administers it
+
+The Workspace super-admin is a shared leadership role mailbox.
+Credentials live in the shared 1Password vault — see [1Password]({{% relref "/global-team/infrastructure/1password" %}}) for how to reach them.
+
+Routing admin through a role mailbox rather than a specific person's account is deliberate.
+Volunteers come and go; the org keeps running.
+When a single human owns the super-admin, their departure becomes a recovery operation rather than a handover.
+
+## Pages in this section
+
+- [Admin Console]({{% relref "admin-console" %}}) — how to reach `admin.google.com`, what lives there, and how to recover if you're locked out.
+- [Chapter emails]({{% relref "chapter-emails" %}}) — the Global Team view of how chapter mailboxes get provisioned. The login and day-to-day usage guides live in the organiser-facing [tech accounts]({{% relref "/organizers/tech/accounts" %}}) and [chapter email]({{% relref "/organizers/tech/email" %}}) pages.
+- [Shared Drive]({{% relref "shared-drive" %}}) — where Global Team meeting notes live and who can read them.
+
+## When the Nonprofit plan stops being enough
+
+The Nonprofit tier covers our needs comfortably today: pooled storage across users, standard Gmail and Drive, basic security controls.
+The two things that would push us off it are running out of storage or wanting features the plan does not include — Vault retention, advanced endpoint management, more aggressive phishing protection.
+If either pressure shows up, the upgrade path is to a paid Workspace tier through the same admin console; nothing about email addresses or accounts changes.
+
+For now, staying on Nonprofit keeps the org's recurring software bill at zero for the thing most chapters interact with daily.

--- a/content/global-team/infrastructure/google-workspace/admin-console.md
+++ b/content/global-team/infrastructure/google-workspace/admin-console.md
@@ -1,0 +1,135 @@
+---
+title: "Workspace Admin Console"
+linkTitle: "Admin Console"
+weight: 10
+---
+
+When someone needs a new chapter mailbox, an old organiser's account suspended, or a forgotten password reset, the work happens at [admin.google.com](https://admin.google.com).
+Signing in there requires the super-admin credentials for the role mailbox, which live in the shared 1Password vault — see [1Password]({{% relref "/global-team/infrastructure/1password" %}}).
+
+## What's there for our footprint
+
+Workspace's admin console exposes dozens of sections; most of them are dark for us because we don't run the corresponding services.
+The handful that matter day-to-day:
+
+- **Directory → Users** — every `@rladies.org` mailbox, including chapter and personal aliases. This is where you provision, suspend, or rename accounts.
+- **Directory → Groups** — distribution lists and shared mailboxes. We keep this list short on purpose; check before creating a new one. TODO: enumerate the groups currently in use and what each one is for, so a new admin can recognise them at a glance.
+- **Billing → Subscriptions** — confirms we're on the Workspace Nonprofit plan and shows the (zero-cost) subscription tied to the Google for Nonprofits programme.
+- **Security → Authentication** — 2-step verification enforcement and recovery options for the super-admin.
+- **Account → Admin roles** — who else, if anyone, holds elevated roles beyond the role mailbox super-admin.
+
+If you find yourself wandering through sections like Devices, Apps, or Vault, you're almost certainly off the well-trodden path.
+Confirm with the team before changing anything there.
+
+## The role of the shared super-admin mailbox
+
+The role mailbox is the only mailbox with full super-admin privileges, and it is shared through 1Password rather than assigned to a specific person.
+That choice is the whole reason the org doesn't have a single-point-of-failure when a volunteer steps back.
+Whoever needs admin access opens 1Password, signs in, does the work, and signs out — no transfer of ownership required.
+
+Resist the temptation to grant an individual's personal `@rladies.org` account super-admin rights "just for convenience."
+That re-introduces the dependency the role mailbox exists to eliminate.
+
+## Provisioning a new chapter mailbox
+
+This is the most-frequent admin task.
+A new chapter onboards, the onboarding team asks the email team to create `cityname@rladies.org`, and the literal click path is:
+
+1. Sign in to [admin.google.com](https://admin.google.com) as the role mailbox using the credentials from 1Password.
+2. In the left sidebar, open **Directory → Users**.
+3. Click **Add new user** at the top of the user list.
+4. Fill in the form:
+   - **First name** — the chapter's display name, e.g. `R-Ladies Buenos Aires`.
+   - **Last name** — leave blank, or use a single character if the form requires it.
+   - **Primary email** — `cityname@rladies.org`, lowercased, no spaces or accents (e.g. `buenosaires@rladies.org`, not `Buenos-Aires@rladies.org`). Match whatever pattern the rest of the directory already uses.
+   - **Secondary email** — leave blank.
+5. Under **Manage user's password**, leave the default _Generate password_ option selected, and tick **Ask for a password change at the next sign-in**.
+6. Under **Send the new account details**, enter the email address of one of the new chapter organisers so the welcome email lands where the chapter can actually read it (the mailbox you're creating obviously can't receive its own welcome email yet).
+7. Click **Add new user**.
+8. Confirm in the **Directory → Users** list that the new mailbox shows as _Active_.
+
+Record the action somewhere durable — the onboarding GitHub issue is the right place, since it's already tracking the chapter's setup steps.
+The organiser-facing walkthrough for what the new chapter does with that welcome email lives at [Chapter Email Access]({{% relref "/organizers/tech/email" %}}); don't duplicate it here.
+
+## Provisioning a personal @rladies.org alias
+
+Since March 2019, personal `name@rladies.org` addresses are issued to Leadership and Global Team members — not to chapter organisers in general.
+When someone joins the Global Team and the onboarding flow flags them for an alias, the admin steps are the same as a chapter mailbox with two differences: the address is a person's name, and there's a real human inbox on the other end to receive the welcome email.
+
+1. Sign in as the role mailbox and open **Directory → Users → Add new user**.
+2. Fill in the form:
+   - **First name** and **Last name** — the person's actual name.
+   - **Primary email** — agree the address with them first (`firstname@rladies.org`, `firstname.lastname@rladies.org`, an initialism — whatever they prefer that doesn't collide with an existing address).
+   - **Secondary email** — their personal address, so the welcome email goes somewhere they can already read.
+3. Leave _Generate password_ selected and tick **Ask for a password change at the next sign-in**.
+4. Click **Add new user**.
+5. Let them know to look for the welcome email; the first-time login flow walks them through the password change.
+
+If the requester isn't on the Global Team or Leadership, push back before provisioning — the alias inventory stays small on purpose.
+
+## Suspending or deleting a departing account
+
+When a chapter goes dormant or a Global Team member steps down, the account stops being used but the question is which lever to pull.
+Three options exist and they aren't interchangeable:
+
+- **Suspend** — the mailbox stops accepting new sign-ins but data is preserved and the address is reserved. Use this for chapters that might come back, or for departures where you're not yet sure whether the inbox holds anything the org still needs. Reversible.
+- **Delete** — the account and its data go away. Use this for permanent shutdowns where nothing in the inbox or Drive matters to the org. Not reversible after Google's grace period (usually 20 days).
+- **Transfer data, then delete** — Google's delete flow offers to transfer the user's Drive files to another `@rladies.org` account first. Use this when the departing account was a personal alias with Drive content (meeting notes, documents) that needs to outlive the person.
+
+Default to **Suspend** when in doubt.
+A suspended account is cheap to keep around and trivial to restore; a deleted one is gone.
+
+The literal click path for suspending:
+
+1. Sign in as the role mailbox and open **Directory → Users**.
+2. Find the user (the search box at the top of the list is faster than scrolling).
+3. Click the user's name to open their profile.
+4. Click **More options** (or the three-dot menu, depending on the current UI) and choose **Suspend user**.
+5. Confirm the suspension.
+
+For deletion, use the same path but choose **Delete user**.
+Google then prompts you to transfer the user's Drive files, calendar events, and so on; pick a destination account (usually a current Global Team alias) if there's anything worth keeping, or skip the transfer if there isn't.
+
+Record the action — including which option you chose and why — alongside the offboarding or chapter-retirement issue.
+
+## Resetting a forgotten password
+
+Chapter organisers occasionally lose track of their mailbox password.
+The reset happens entirely in the admin console:
+
+1. Sign in as the role mailbox and open **Directory → Users**.
+2. Find and click the user whose password needs resetting.
+3. On their profile, click **Reset password**.
+4. Leave _Automatically generate a password_ selected (or set a temporary one yourself), and tick **Ask for a password change at the next sign-in**.
+5. Click **Reset**.
+6. Google displays the temporary password on screen.
+   Copy it.
+
+Send the temporary password to the organiser through a channel _other_ than the mailbox you just reset — Slack DM, their personal email, whichever is already verified for them.
+Emailing the temp password to the mailbox itself defeats the entire point.
+
+## Review cadence
+
+Roughly every six months, someone on the Global Team should sign in as the role mailbox and:
+
+1. Open **Account → Admin roles** and confirm the list of admins matches who should currently hold elevated access.
+2. Open **Directory → Users** filtered to suspended accounts and clear out any that have been suspended long enough to safely delete.
+3. Open **Security → Alert center** to skim any flagged sign-ins or policy issues from the last six months.
+4. Open **Billing → Subscriptions** to confirm the Workspace Nonprofit subscription is still active. TODO: confirm whether Google for Nonprofits requires periodic re-verification and where the renewal notice lands; document the renewal flow once the cadence is known.
+
+Six months is a reasonable beat for a volunteer org our size — frequent enough to catch drift, infrequent enough that nobody dreads it.
+The Workspace admin console surfaces most of what you need without leaving the page.
+
+## Troubleshooting
+
+**"I can't sign in to the admin console"**
+: First, confirm you're using the role mailbox credentials from 1Password — _not_ your personal `@rladies.org` account, which won't have admin rights.
+If 1Password itself is the blocker (you don't have access yet, or the vault entry looks stale), reach out to leadership on Slack rather than trying to recover the account through Google's flow.
+
+**"I'm signed in but the menu items above are missing"**
+: You're probably signed in with a regular `@rladies.org` account that lacks admin privileges. Sign out, then sign back in as the role mailbox.
+
+**"Google is asking for a recovery code or backup phone"**
+: Stop and check 1Password before tapping any of the recovery options.
+The recovery numbers and codes for the role mailbox are stored alongside the password.
+Triggering a recovery flow without them risks locking the org out of its own admin console.

--- a/content/global-team/infrastructure/google-workspace/chapter-emails.md
+++ b/content/global-team/infrastructure/google-workspace/chapter-emails.md
@@ -1,0 +1,21 @@
+---
+title: "Chapter email addresses"
+linkTitle: "Chapter emails"
+weight: 20
+---
+
+Every chapter mailbox at `yourcity@rladies.org` is a Google Workspace account in our tenant, provisioned through the admin console by whoever is currently signed in as the role mailbox.
+From the Global Team angle there isn't much more to it: a new chapter onboards, the email team creates the account, and Workspace sends the welcome email to the new organisers.
+
+The actual usage docs — what to do with the welcome email, how to sign in, how to set up the account on a phone, how to manage password resets — live in the organiser-facing section and should not be duplicated here.
+
+If you're doing anything _to_ a chapter mailbox, start with:
+
+- [Tech infrastructure for chapters → E-Mail]({{% relref "/organizers/tech/accounts#e-mail" %}}) — the chapter-side overview, including what the address is for and how it interacts with Slack and Meetup.
+- [How to access your rladies.org email address]({{% relref "/organizers/tech/email" %}}) — the login walkthrough, including the welcome email template, webmail, and smartphone setup.
+
+If you're doing anything _about_ provisioning, deleting, or troubleshooting a mailbox at the Workspace level, the runbooks live on the [Admin Console]({{% relref "admin-console" %}}) page:
+
+- [Provisioning a new chapter mailbox]({{% relref "admin-console#provisioning-a-new-chapter-mailbox" %}}) — the literal click path from sign-in to welcome email.
+- [Suspending or deleting a departing account]({{% relref "admin-console#suspending-or-deleting-a-departing-account" %}}) — when to suspend, when to delete, when to transfer Drive data first.
+- [Resetting a forgotten password]({{% relref "admin-console#resetting-a-forgotten-password" %}}) — admin-console reset plus how to deliver the temp password without sending it to the locked-out mailbox.

--- a/content/global-team/infrastructure/google-workspace/organisation-and-policies.md
+++ b/content/global-team/infrastructure/google-workspace/organisation-and-policies.md
@@ -1,0 +1,234 @@
+---
+title: "Organisation, OUs, Groups, and policies"
+linkTitle: "Organisation & policies"
+weight: 40
+---
+
+The default Google Workspace tenant places every user account — chapter mailbox, personal alias, service account — in one bucket with one set of policies.
+That works while the org is small, but every new chapter widens the policy compromise: enforce strict 2FA and chapter co-organisers can't share access; relax it and the leadership accounts inherit the looser stance.
+The fix is structural.
+
+This page documents the recommended target shape for the RLadies+ Workspace tenant — the Organisational Units, Groups, lifecycle conventions, and DNS-level security that the current flat layout doesn't yet have.
+Almost nothing here is already implemented; treat the page as the plan, not the snapshot.
+Each section names what's in place today versus what's a TODO for the maintainer.
+
+## Why structure matters now
+
+Today the tenant is essentially flat: one default Organisational Unit holds every mailbox, a handful of Groups exist but aren't enumerated, and chapter mailboxes sit under the same authentication policy as the role mailbox.
+The friction this creates is mostly invisible until the day a policy needs to change.
+At that point every change is global — there's no way to enforce hardware-key 2FA on the super-admin without simultaneously demanding it of a Buenos Aires co-organiser who shares the mailbox over Signal.
+
+Splitting the tenant into Organisational Units gives the admin a place to apply different policies to different kinds of account.
+Splitting routing into named Groups gives the admin a way to add and remove people from distribution lists without rewriting BCC fields.
+Both are cheap to set up while the directory is small; both compound in value as the chapter list grows.
+
+## Organisational Units
+
+The recommended OU layout has five buckets, each justified by a policy difference the current flat tenant can't express.
+
+TODO: maintainer to create these OUs in admin.google.com and apply the policies described.
+None of the OUs below exist in the tenant yet beyond the default root.
+
+| OU                  | Members                                                                   | Why this OU                                                                                                                                                                                                                                                                                              |
+| ------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/Service accounts` | `accounts@`, future role mailboxes                                        | Strictest 2FA (hardware key or passkey), shortest session length, full audit logging. These accounts hold elevated privilege and have no day-to-day human user who'd object to the friction.                                                                                                             |
+| `/Global Team`      | Personal `name@rladies.org` for leadership and Global Team members        | Enforced 2FA, app-access controls that match a real person's working pattern. These users sign in regularly and can be expected to maintain their own credentials.                                                                                                                                       |
+| `/Chapters/Active`  | All current chapter mailboxes                                             | 2FA recommended but not forced. Chapter mailboxes are shared between co-organisers, and enforced 2FA on a shared inbox tends to push organisers towards storing the second factor somewhere it shouldn't live. Broader app access since organisers genuinely use Calendar, Meet, and occasionally Drive. |
+| `/Chapters/Dormant` | Chapter mailboxes whose chapter has gone quiet but isn't formally retired | Login suspended; data retained. Acts as a holding pen between "active" and "deleted" so a chapter revival doesn't lose its history.                                                                                                                                                                      |
+| `/Alumni`           | Departed Global Team personal aliases in their grace period               | Login disabled, forwarding only. See [Personal alias offboarding](#personal-alias-offboarding) below for the timeline.                                                                                                                                                                                   |
+
+The literal click path for creating an OU:
+
+1. Sign in to [admin.google.com](https://admin.google.com) as the role mailbox using the credentials from [1Password]({{% relref "/global-team/infrastructure/1password" %}}).
+2. In the left sidebar, open **Directory → Organizational Units**.
+3. Click **+ Create new organizational unit** at the top of the page.
+4. Fill in the **Name** (e.g. `Service accounts`) and an optional **Description** explaining the policy intent.
+5. For nested OUs like `/Chapters/Active`, first create `Chapters`, then create `Active` with `Chapters` selected as the parent.
+6. Click **Create**.
+
+To move a user into an OU after the OU exists:
+
+1. Open **Directory → Users** and find the user.
+2. Click their name to open their profile.
+3. Click **More options** (the three-dot menu) and choose **Change organizational unit**.
+4. Select the target OU and click **Continue**, then **Change**.
+
+TODO: maintainer to define the policy bundle (2FA enforcement level, session length, app access) on each OU once created.
+The OU is just the container; the policies are configured separately under **Security** and **Apps** in the admin console and need to be reviewed against the table above.
+
+### Worked example: enforcing 2FA on `/Service accounts`
+
+The canonical case is forcing 2-step verification on the service-account OU.
+The same select-OU-then-set pattern applies to every other policy in the admin console — session length, app access, less-secure-app permissions — so this example doubles as the template for the rest.
+
+1. Sign in to [admin.google.com](https://admin.google.com) as the role mailbox.
+2. Open **Security → Authentication → 2-step verification**.
+3. In the left-hand OU selector, click **Service accounts** so the panel scopes to that OU only — the heading should now read "Settings for Service accounts" rather than the root org.
+4. Tick **Allow users to turn on 2-step verification** if it isn't already on.
+5. Under **Enforcement**, choose **On** (or **On from a specific date** if a grace period is needed).
+6. Set the **Enrollment period** to something short — two weeks is enough for a single role mailbox — so accounts that haven't enrolled get blocked rather than living indefinitely without 2FA.
+7. Under **Methods**, restrict to **Security key** or **Any except verification codes via text, phone call** so the strictest factor is required for the strictest OU.
+8. Click **Save**.
+
+Every policy in the admin console can be scoped to an OU using this same pattern: open the policy, select the target OU from the left-hand selector, set the values, save.
+
+## Groups strategy
+
+Right now distribution happens through ad-hoc BCC lists and personal memory of who's on which team.
+That's the failure mode where a new finance lead doesn't get looped in on a vendor email for three months because the previous lead's mental BCC list never made it into anyone else's head.
+
+Formalising routing through Google Groups fixes the handover problem.
+A Group has membership the admin can read off a page; a BCC list has membership in someone's drafts folder.
+
+Recommended Groups, with the recommended access type in parentheses:
+
+- `leadership@rladies.org` (Only members can post; members-only visibility) — routes to whoever holds Leadership roles this year. Used for external partners who need "someone in charge".
+- `global-team@rladies.org` (Only members can post; members-only visibility) — routes to every active Global Team member's personal alias. Used for internal coordination that everyone needs to see.
+- `directory@rladies.org` (Anyone on the web can post; anyone in the org can view members) — routes to the Directory team for chapter listing and onboarding questions. This one is public-posting on purpose because would-be chapter leads need to reach it from any address.
+- `mentoring@rladies.org` (Anyone on the web can post; members-only visibility) — routes to the Mentoring team for programme enquiries.
+- `social-media@rladies.org` (Only members can post; members-only visibility) — routes to the social media team for cross-platform requests.
+- `finance@rladies.org` (Only members can post; members-only visibility) — routes to whoever currently handles invoicing and reimbursements.
+- `chapters@rladies.org` (Only members can post; anyone in the org can view members) — routes to every active chapter mailbox. Used sparingly, for genuinely-org-wide announcements only.
+- `chapters-new@rladies.org` (Only managers can post; members-only visibility) — routes to chapters in their first six months. Used for onboarding-specific announcements that established chapters can skip.
+
+Access type lives on the group's Settings page at `groups.google.com/a/rladies.org/g/<group>/about` (open the group, click the gear icon, then **General**).
+This setting matters disproportionately because the wrong choice on a public-posting group is exactly how spam arrives at hundreds of inboxes at once: a single open list that fan-outs to every chapter mailbox is the difference between zero spam and a coordinated wave.
+Set it deliberately at create time and review it whenever a group's purpose changes.
+
+Every group needs at least one Owner who is a human, in addition to the role account.
+At create time, set the team lead as Owner and the role mailbox as a secondary Owner (or as the only Owner if no team lead exists yet).
+The convention: every group has at least one human owner besides the role account, so a single departure doesn't leave the group unmanaged.
+
+Optional regional sub-groups (`chapters-emea@`, `chapters-americas@`, `chapters-apac@`) become worth the maintenance overhead once an announcement is genuinely regional rather than global.
+Leave them out until that need is concrete.
+
+The literal click path for creating a Group:
+
+1. Sign in to [admin.google.com](https://admin.google.com) as the role mailbox.
+2. Open **Directory → Groups**.
+3. Click **+ Create group**.
+4. Fill in **Name** (human label), **Email** (the `@rladies.org` address), and **Description** (one line explaining what the group routes).
+5. Set **Access type** — for most of the Groups above this is _Restricted_ (only members can post) or _Team_ (members plus other org users can post), depending on who legitimately needs to email the list.
+6. Click **Create group**, then add members from the next screen.
+
+TODO: maintainer to enumerate the Groups that already exist in the tenant and reconcile with the list above — some may already be in place, some may need creating, and any orphaned groups from previous setups should be cleaned up.
+
+## Chapter mailbox lifecycle
+
+Chapters go quiet.
+Sometimes they come back, sometimes they don't, and the current process for deciding when to delete a mailbox is essentially "remember to look at it eventually".
+The recommended convention is a two-step decay:
+
+1. **Inactive for 12 months** → move the mailbox to `/Chapters/Dormant`. Login is suspended (so the address can't be used to send mail or sign in), but the data is preserved. The chapter still appears in the directory as dormant rather than vanishing.
+2. **24 months in dormant** (so 36 months total of inactivity) → transfer any salvageable Drive content to the role mailbox, then delete the account. At this point the chapter has had three years to come back and hasn't; the mailbox is overhead with no audience.
+3. **Chapter revives at any point before deletion** → reactivate from dormant. The data is intact, the address is unchanged, and the co-organisers pick up where the previous group left off.
+
+The "how to suspend vs delete" mechanics — the literal click path, the data transfer dialog, when Google's grace period ends — already live in the [Admin Console runbook]({{% relref "admin-console#suspending-or-deleting-a-departing-account" %}}).
+This page only adds the timing convention; don't duplicate the mechanics here.
+
+TODO: maintainer to apply the lifecycle convention.
+Today the call to suspend vs delete is ad-hoc; adopting the 12/24-month rule requires (a) agreeing it formally, (b) auditing the current chapter mailboxes for inactivity, and (c) moving any that already qualify into `/Chapters/Dormant` once the OU exists.
+
+## Personal alias offboarding
+
+Leadership and Global Team members rotate.
+When they do, the current behaviour is to suspend the alias and forget about it.
+That works until someone emails the departed person at their `@rladies.org` address two years later and gets silence rather than a useful redirect.
+
+The recommended convention is a three-stage decay:
+
+- **Day 0** — leadership departure confirmed. Move the alias from `/Global Team` to `/Alumni`. Set up forwarding (see below) and disable login.
+- **Day 1 through Day 90** — incoming mail forwards automatically to the role mailbox, or to the person's personal address if they've explicitly opted in. Three months is long enough for stragglers to notice the address has changed and update their records.
+- **Day 90** — delete the account. The Workspace seat returns to the pool and the address stops accepting mail.
+
+Forwarding is configured per-user under **Apps → Google Workspace → Gmail → Routing**, or by signing in as the user one last time and setting forwarding from the mailbox's own settings.
+The first approach is cleaner because it doesn't require touching the user's credentials.
+
+Add this offboarding step to the Global Team offboarding checklist that lives in the [onboarding flow]({{% relref "/global-team/onboarding" %}}) — the same checklist that creates the alias is the right place to record how it gets retired.
+
+TODO: maintainer to (a) create the `/Alumni` OU, (b) decide the default forwarding destination, and (c) add the offboarding step to the existing checklist.
+
+## Shared Drives instead of My Drive
+
+Anything important enough to outlive its author belongs in a Shared Drive, not a personal My Drive.
+The failure mode the existing [Shared Drive page]({{% relref "shared-drive" %}}) describes — documents lost when a creator's account is suspended — only applies to My Drive content.
+Shared Drives are owned by the tenant.
+
+The recommended layout is one Shared Drive per Global Team function:
+
+- Leadership
+- Mentoring
+- Finance
+- Social Media
+- Directory
+- Onboarding
+
+Each Drive gets the team lead as Manager and the team members as Contributor.
+External collaborators get Viewer or Commenter scoped to specific files rather than full Drive membership.
+
+The mechanics for granting access — the click path through **Manage members**, the choice of role — already live in the [Shared Drive page]({{% relref "shared-drive#granting-a-new-global-team-member-access" %}}); this page only adds the convention that each function gets its own Drive rather than sharing one big "Global Team" Drive.
+
+TODO: maintainer to inventory the Shared Drives that currently exist and decide which need creating, renaming, or consolidating against the function list above.
+
+## Email security at the DNS layer
+
+`rladies.org` needs SPF, DKIM, and DMARC configured correctly or legitimate Workspace mail starts silently landing in recipients' spam folders.
+The failure is silent because Google doesn't refuse to send the mail — the receiving server quietly downgrades it.
+
+The DNS records themselves live at Cloudflare, since Cloudflare is the DNS host for `rladies.org`.
+The Workspace side of DKIM (the key generation) happens in the admin console; the matching public key has to be published as a DNS record at Cloudflare for receiving servers to verify signatures.
+
+To check the Workspace side:
+
+1. Sign in to [admin.google.com](https://admin.google.com) as the role mailbox.
+2. Open **Apps → Google Workspace → Gmail → Authenticate email**.
+3. Confirm a DKIM key is generated for `rladies.org` and copy the TXT record value.
+4. Verify that record exists at Cloudflare against the expected host (typically `google._domainkey.rladies.org`).
+
+SPF and DMARC don't have a Workspace-side configuration — they're DNS-only.
+The records live at Cloudflare; see the [Cloudflare]({{% relref "/global-team/infrastructure/cloudflare" %}}) page for how to reach the DNS dashboard and what the records should contain.
+
+To verify the records are correct from the outside, point a public inspector at `rladies.org` — [mxtoolbox.com/dmarc](https://mxtoolbox.com/dmarc) or the equivalent on [dmarcian](https://dmarcian.com/dmarc-inspector/) will report all three checks (SPF pass/fail, DKIM signature alignment, DMARC policy and percentage) in one view.
+For the Workspace-side DKIM key status, go to admin.google.com → **Apps → Google Workspace → Gmail → Authenticate email** and confirm the status reads _Authenticating email_ rather than _Not authenticating email_ or _Generating DKIM key_.
+Both views should show green; if either is broken, mail starts landing in spam silently and nobody on the sending side gets an error.
+
+TODO: maintainer to verify the current state of SPF, DKIM, and DMARC for `rladies.org` and document the actual record values.
+A DMARC report aggregator (the free tier of a service like Postmark or dmarcian) is worth setting up so the maintainer sees the bounce/spam reports rather than relying on individuals to flag missing mail.
+
+## Recovery drill
+
+Every six months, a leadership member who is _not_ the primary holder of the 1Password vault should attempt to sign in to the role mailbox end-to-end — from opening 1Password, through the 2FA challenge, into the admin console.
+If they can't, the recovery configuration is broken in a way no one would notice until the day it actually matters.
+
+What running the drill looks like:
+
+1. Open a fresh incognito (or private) window so no existing session masks a credential problem.
+2. Navigate to [admin.google.com](https://admin.google.com) and enter the role mailbox.
+3. Pull the password from the shared [1Password]({{% relref "/global-team/infrastructure/1password" %}}) vault and paste it in.
+4. When prompted for 2FA, complete the challenge — either using the TOTP code from 1Password's authenticator field, or, if that fails, the SMS fallback to the recovery phone number on file.
+5. Confirm the admin console loads with the expected privileges (Directory, Security, Apps all visible in the sidebar).
+6. Sign out and close the incognito window.
+7. If any step failed — wrong password, missing TOTP, no SMS arriving, console missing privileges — raise it on the leadership Slack channel that day, before anyone forgets which step broke.
+
+This is not a fire drill to be done dramatically.
+It's a calendar habit, scheduled alongside the [admin console review cadence]({{% relref "admin-console#review-cadence" %}}).
+The output is either "yes, I got in" or "no, and here's where it failed", and the latter triggers a fix immediately rather than at the next emergency.
+
+TODO: maintainer to schedule the first drill and document who runs it.
+Pair the drill with the existing six-monthly admin review so it slots into a habit that already exists rather than competing for a new calendar slot.
+
+## Migration plan
+
+Moving from the current flat tenant to the structure above is a real project, not an afternoon's work.
+The sequence below minimises disruption by changing the container before changing the contents, and by moving low-traffic accounts before high-traffic ones.
+
+1. **Create the OUs** in the order `/Service accounts`, `/Global Team`, `/Chapters/Active`, `/Chapters/Dormant`, `/Alumni`. No users are moved yet; empty OUs are harmless. _Verify_: each OU appears under **Directory → Organizational Units** with the expected parent.
+2. **Define policies per OU** in the admin console. Test each policy against a single test account before applying broadly. _Verify_: open the policy (e.g. 2-step verification) with the OU selected and confirm the panel reads "Settings for &lt;OU name&gt;" with the intended values.
+3. **Move the role mailbox** into `/Service accounts` first. This is the highest-stakes account but also the one with the smallest blast radius if something goes wrong, because only the admin uses it. Run the recovery drill immediately after. _Verify_: open the user profile and confirm the **Organizational unit** field shows `/Service accounts`.
+4. **Move Global Team personal aliases** into `/Global Team`. Tell people the move is happening so they can flag any unexpected login prompts that follow. _Verify_: spot-check two or three aliases in **Directory → Users** and confirm the OU column matches.
+5. **Move chapter mailboxes** into `/Chapters/Active` last, in batches of ten or twenty. Warn co-organisers a week in advance so a sudden 2FA prompt doesn't read as a phishing attempt. _Verify_: filter the user list by OU `/Chapters/Active` and confirm the count matches the batch just moved.
+6. **Stand up the Groups** in parallel with the OU moves. Groups don't depend on OU structure, so this work can happen any time. _Verify_: send a test message to each new group from an external address and confirm it lands in at least one member's inbox.
+7. **Run the recovery drill** after each major move, not just at the end. Drift compounds; catch it early. _Verify_: the drill itself is the verification — the pass criterion is the incognito sign-in completing end-to-end.
+
+TODO: this entire migration is the recommended next chunk of work, not work already done.
+Track it as a single GitHub issue so the steps stay sequenced and the maintainer can check off each one as it completes.

--- a/content/global-team/infrastructure/google-workspace/shared-drive.md
+++ b/content/global-team/infrastructure/google-workspace/shared-drive.md
@@ -1,0 +1,54 @@
+---
+title: "Shared Drive and meeting notes"
+linkTitle: "Shared Drive"
+weight: 30
+---
+
+Most of what the Global Team produces collaboratively — meeting agendas, retrospective notes, the occasional draft document — lives in Google Drive under the `rladies.org` tenant, not in any chapter's personal Drive.
+Keeping it there means the documents survive a volunteer rotation: when someone steps down, the notes stay with the org rather than disappearing into a personal Google account.
+
+## Where things live
+
+TODO: Confirm and link the actual Shared Drive name and URL where Global Team meeting notes live.
+
+In broad strokes, Global Team meeting notes are kept in a Shared Drive (not "My Drive") so ownership belongs to the tenant rather than any single user.
+A document created in a Shared Drive cannot be silently lost when its creator's account is suspended, which is the failure mode we're explicitly avoiding.
+
+## Who can access
+
+Access is granted by the role mailbox super-admin or by an existing manager of the relevant Shared Drive.
+The default expectation is that any current Global Team member with an `@rladies.org` personal alias can read meeting notes; write access is scoped to the people who run the meetings.
+
+TODO: Document the exact group or membership pattern used to grant access (e.g. whether membership is a Workspace group, a Shared Drive ACL, or both).
+
+### Granting a new Global Team member access
+
+When someone joins the Global Team and needs to read or edit meeting notes, the literal path is:
+
+1. Open [drive.google.com](https://drive.google.com) signed in as either the role mailbox or your own `@rladies.org` alias if you already have manager rights on the Drive in question.
+2. In the left sidebar, click **Shared drives** and open the Drive you're granting access to. TODO: name the specific Shared Drive(s) Global Team members typically need (meeting notes, retrospectives, etc.) and link them here once confirmed.
+3. Click **Manage members** (the people icon near the top right of the Drive view).
+4. In the **Add people and groups** box, type the new member's `@rladies.org` alias.
+5. Pick the right role:
+   - **Viewer** — read-only access. Fine for anyone who just needs to follow along.
+   - **Commenter** — read plus inline comments. Useful for reviewers.
+   - **Contributor** — can edit existing files but can't move or delete them. The usual default for a working Global Team member.
+   - **Content manager** — full edit, move, and delete on files. Reserve for people who actively curate the Drive.
+   - **Manager** — full control including membership. Reserve for the small set of people who run the relevant function.
+6. Untick the _Notify people_ box if you've already told them out-of-band; otherwise let Google send the notification.
+7. Click **Send** (or **Share** depending on the current UI label).
+
+If the person doesn't have a personal `@rladies.org` alias yet, provision that first via the [admin console]({{% relref "admin-console#provisioning-a-personal-rladiesorg-alias" %}}) — Shared Drives won't accept a personal Gmail address for our tenant.
+
+## Naming and retention
+
+TODO: Confirm the team's actual naming convention for meeting notes (date prefix, meeting name, etc.) and the retention practice — whether anything is archived, deleted, or moved after a certain period.
+
+In the absence of a documented convention, the safe default is to keep notes indefinitely.
+Drive storage on the Nonprofit plan is generous, and old notes have repeatedly turned out to be useful when a question resurfaces a year later about why a decision was made.
+
+## When to use Drive vs somewhere else
+
+Drive is for working documents — agendas, drafts, notes that the team needs to edit together.
+Once a decision or policy is finalised, it usually wants to migrate _out_ of Drive and into a more durable home: this guide, a repo README, or an Airtable record, depending on what kind of thing it is.
+Documents that only ever live in Drive tend to get forgotten; documents that get promoted into the public guide get maintained.


### PR DESCRIPTION
## Summary

Adds a new `content/global-team/infrastructure/google-workspace/` subsection covering how RLadies+ uses its Google Workspace Nonprofit tenant.

The subsection has five pages:

- `_index.en.md` — overview: what plan we're on, what we actually use Workspace for (email + the occasional shared doc), and the shared super-admin role-mailbox pattern.
- `admin-console.md` — operational runbook: how to reach `admin.google.com`, the handful of menu paths that matter, the six-monthly review cadence, sign-in troubleshooting, and step-by-step click paths for the common admin tasks (chapter mailbox provisioning, alias provisioning, suspend/delete/transfer, password reset).
- `chapter-emails.md` — short signpost directing readers to the existing organiser-facing email/accounts pages.
- `shared-drive.md` — Global Team meeting notes context, member-access click path with role explainer, and TODO markers where exact Drive URLs need filling in.
- `organisation-and-policies.md` — target-state recommendation: OU structure, Groups strategy, chapter mailbox lifecycle, personal alias offboarding, SPF/DKIM/DMARC verification, six-monthly recovery drill, and a seven-step migration plan with per-step verification.

Stacks on #207.

## Test plan

- [x] Hugo builds cleanly
- [ ] Confirm cross-references to 1Password, Cloudflare, organiser-facing email pages, and the in-section runbooks resolve after stacked merges
- [ ] Fill the TODO markers (Shared Drive URLs, group inventory, current OU/policy state for the migration plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)