### PR TITLE
Document the nonprofit administration stack (VCorp, OpenPhone, AnytimeMailbox)

### DIFF
--- a/content/global-team/nonprofit-administration/_index.en.md
+++ b/content/global-team/nonprofit-administration/_index.en.md
@@ -1,0 +1,22 @@
+---
+title: "Nonprofit administration"
+linkTitle: "Nonprofit administration"
+weight: 105
+chapter: false
+---
+
+RLadies+ is a US-registered 501(c)(3) nonprofit, headquartered in California, run entirely by volunteers — none of whom necessarily live in California.
+Keeping the org compliant and reachable as a corporate entity, despite the absence of a physical office, depends on three external services.
+Each one handles a piece of the "we exist as a legal entity" surface that a traditional office would otherwise provide.
+
+The three:
+
+- [VCorp]({{% relref "vcorp" %}}) is the registered agent and compliance partner — handles California state filings, the annual Form 990, and forwards any official notices the state or IRS send to the registered-agent address.
+- [OpenPhone]({{% relref "openphone" %}}) gives the org a US phone number that isn't tied to any single volunteer's personal phone — donors, sponsors, and venue partners can call one number that any leadership member can pick up.
+- [AnytimeMailbox]({{% relref "anytime-mailbox" %}}) provides the California business address printed on RLadies+'s 501(c)(3) paperwork and on every donor receipt — physical mail to that address is scanned and uploaded within hours.
+
+Credentials for all three live in the Shared vault — see [1Password]({{% relref "/global-team/infrastructure/1password" %}}) for the login and recovery details.
+Recovery on these services flows through the shared leadership role mailbox; if it is unreachable, restore Workspace admin access first via the [Google Workspace admin console]({{% relref "/global-team/infrastructure/google-workspace/admin-console" %}}#troubleshooting) procedure.
+
+Tax filings, the annual Form 990, and the relationship with the California Franchise Tax Board are operated through VCorp, but the leadership decisions behind them (which form, which financial year, what to declare) are on us.
+The [finance section]({{% relref "/global-team/finance" %}}) is the source-of-truth for the numbers VCorp files.

--- a/content/global-team/nonprofit-administration/anytime-mailbox/index.en.md
+++ b/content/global-team/nonprofit-administration/anytime-mailbox/index.en.md
@@ -1,0 +1,110 @@
+---
+title: "AnytimeMailbox (virtual business address)"
+linkTitle: "AnytimeMailbox"
+weight: 30
+---
+
+The address printed on RLadies+'s 501(c)(3) documents, on every donor receipt, and on every form California asks the org to fill in is an AnytimeMailbox location in Oakland.
+Physical mail sent to that address arrives at a real building staffed by real people who open the envelopes, scan the contents, and upload them to a dashboard within hours.
+The org can therefore have a US business address — required by California for nonprofit registration — without any leadership member having to live nearby or check a physical PO box.
+
+## What AnytimeMailbox does
+
+AnytimeMailbox ([anytimemailbox.com](https://www.anytimemailbox.com)) operates a network of physical mail-handling locations that rent street addresses to remote businesses.
+For RLadies+, the Oakland address handles:
+
+- **Receiving physical mail and packages** on behalf of the org.
+- **Scanning envelope exteriors** as soon as items arrive; on request, scanning the contents.
+- **Forwarding originals** to any address (typically only when leadership specifically needs the physical document — most things stay digital), or **shredding** after scanning for the routine paper that doesn't need keeping.
+- **Acting as the printed mailing address** on every official document, donor receipt, grant application, and tax filing.
+
+California requires every registered nonprofit to have a physical street address on file with the Secretary of State; a PO box won't satisfy the requirement.
+AnytimeMailbox's street address does — that's why this service exists in the stack rather than just a cheaper PO box.
+
+## The address
+
+TODO: confirm whether the actual street address belongs in this page.
+The address is public (it's on donor receipts and the website's donation page) so probably yes; flagging for the maintainer to fill in or to point at the canonical record in the website repo if preferred.
+
+## Plan
+
+TODO: confirm AnytimeMailbox tier (typically Basic / Plus / Premium tiers differ on scan-page allowance and forwarding turnaround) and the monthly cost.
+
+## Who has access
+
+- Admin tied to the shared leadership role mailbox; credentials in the [1Password]({{% relref "/global-team/infrastructure/1password" %}}) Shared vault.
+- Leadership members handling mail-triage duties should have their own logins.
+- TODO: list current AnytimeMailbox users and their roles.
+
+## Operational tasks
+
+### Signing in
+
+1. Open the AnytimeMailbox Customer Portal — TODO: confirm exact URL (typically [anytime-mailbox.com](https://www.anytime-mailbox.com) → Customer Login).
+2. Sign in with credentials from 1Password.
+3. Complete 2FA.
+
+### Reviewing the inbox
+
+1. The **Mail** tab is the dashboard for everything received.
+2. Items are sorted by date with a thumbnail of the envelope exterior.
+3. New items have an "unactioned" state — they sit there until someone tells AnytimeMailbox what to do.
+
+The right cadence is weekly: someone walks the list, decides per item, clears the unactioned queue.
+
+### Per-item actions
+
+For each unactioned item, there are four common paths:
+
+- **Open & Scan & Shred** — for routine paper that has informational value (a thank-you note from a partner, a check stub) but no need to keep the physical: AnytimeMailbox opens, scans the contents into the dashboard, and shreds the physical. This is the default for most mail.
+- **Open & Scan & Hold** — same as above, but keep the physical at the facility for later forwarding. Use for anything that might need to be physically presented somewhere (rare).
+- **Forward** — AnytimeMailbox ships the original to a specified address. Use for cheques (which need physical deposit), original signed documents the IRS may request, and anything Wise / Relay specifically asks for in original form. Choose shipping speed at request time.
+- **Shred** — for obvious junk mail (offers, advertisements). The envelope exterior scan is usually enough to identify it.
+
+The click path:
+
+1. Click the envelope in the Mail tab.
+2. **Actions** dropdown → choose the action.
+3. Confirm; AnytimeMailbox staff process within their published turnaround (typically same-day for scans, 1-2 days for forwarding).
+
+### Forwarding a piece of mail to a leadership member
+
+1. Click the item → **Actions** → **Forward**.
+2. Enter the destination address.
+3. Choose shipping option (USPS first-class is fine for most documents; FedEx for anything time-sensitive or valuable).
+4. Confirm; AnytimeMailbox charges the per-shipment fee to the account.
+
+### Picking up a package
+
+Packages (rather than letter mail) sometimes can't be forwarded cheaply.
+For these, contact AnytimeMailbox's location directly using the contact info in the portal; arrange local pickup or pay the higher package-shipping rate.
+
+### Setting up email notifications
+
+1. **Settings** → **Notifications**.
+2. Enable notifications for new arrivals so leadership knows when something needs triaging.
+3. Choose where they're sent — typically the role mailbox plus the named primary triager.
+
+### Adding an authorised recipient name
+
+Mail addressed to a name not on the authorised recipient list may be refused or held indefinitely.
+For RLadies+, the authorised list should include the org's legal name, common abbreviations (RLadies+, R-Ladies Global, etc.), and any past or present officer names that may still appear on legacy correspondence.
+
+1. **Settings** → **Authorised Recipients** → **Add**.
+2. Enter the name.
+3. Save.
+
+Walk the list every six months and prune anything stale.
+
+## Recovery
+
+2FA codes in 1Password; recovery email is the shared role mailbox, so Workspace access is the prerequisite.
+If the AnytimeMailbox account itself is unreachable, the facility location can be contacted directly (location address and phone number in the portal) to confirm continued mail receipt while the account access is restored.
+
+## Things to watch for
+
+- **Pending mail accumulating.** A backlog of unactioned items is how genuinely important notices get missed. Set the weekly review cadence and stick to it.
+- **Mail to former-officer names.** Five years on, old donor databases still occasionally send to founders or past treasurers. Either keep those names on the authorised list (so the mail is received and triaged) or accept it'll bounce.
+- **Tax-season spikes.** January through April brings more government correspondence than any other quarter. Plan for it.
+- **Subscription auto-renewal.** Billing notifications land on the role mailbox; forward to the finance-responsible leadership member for monthly reconciliation alongside Relay/Wise/PayPal.
+- **Service-of-process documents.** If anything that looks like a legal summons arrives, route it to VCorp immediately (cross-link [VCorp]({{% relref "../vcorp" %}})) — there are statutory response windows on legal documents that don't pause for triage.

--- a/content/global-team/nonprofit-administration/openphone/index.en.md
+++ b/content/global-team/nonprofit-administration/openphone/index.en.md
@@ -1,0 +1,103 @@
+---
+title: "OpenPhone (shared US phone number)"
+linkTitle: "OpenPhone"
+weight: 20
+---
+
+A donor calling the number on RLadies+'s 501(c)(3) paperwork, an event venue confirming a booking, a sponsor following up on an email — they all dial one US number.
+The call lands in a shared OpenPhone inbox that any leadership member can pick up, from their laptop or their phone, with no need to give out anyone's personal number.
+
+## What OpenPhone does
+
+OpenPhone ([openphone.com](https://openphone.com)) is a cloud phone service designed for teams.
+The RLadies+ setup uses it for:
+
+- **One shared US phone number** — the official RLadies+ contact number, printed on tax documents, the website's contact page, and grant applications. TODO: confirm the actual number (it's in 1Password and on the website; decide whether to print it here too).
+- **Voicemail with transcription** — voicemails arrive in the inbox with a text transcript, so a quick scan tells you whether to listen or not.
+- **Shared team inbox for SMS** — texts to the number land in a thread any team member can reply to.
+- **Desktop and mobile apps** — leadership can pick up calls from anywhere; outgoing calls show the RLadies+ number as caller ID rather than the personal number.
+
+## Plan
+
+TODO: confirm whether RLadies+ is on OpenPhone's Starter or Business tier, and whether the nonprofit pricing programme applies.
+Starter covers a single number; Business adds analytics, scheduled messages, and integration with other tools.
+
+## Who has access
+
+- Admin tied to the shared leadership role mailbox; credentials in the [1Password]({{% relref "/global-team/infrastructure/1password" %}}) Shared vault.
+- Leadership members are added as Workspace Members with their own logins.
+- TODO: list current OpenPhone members.
+
+## Operational tasks
+
+### Signing in
+
+1. Open [my.openphone.com](https://my.openphone.com) or download the desktop or mobile app.
+2. Sign in with your individual OpenPhone credentials (or the admin login from 1Password for admin operations).
+3. Complete 2FA.
+
+### Listening to a voicemail
+
+1. Open the OpenPhone app or web client.
+2. Click **Phone** → **Inbox**.
+3. New voicemails appear at the top with a transcript preview.
+4. Click to read the transcript, or play the audio.
+5. Mark the message as resolved (or reply) so it doesn't dangle in the shared inbox.
+
+### Returning a call
+
+1. From a voicemail or a missed call, click the number → **Call back**.
+2. Or **Phone** → **+ New call** → select the RLadies+ number as caller ID → dial.
+3. The recipient sees the RLadies+ number, not your personal one.
+
+### Replying to an SMS
+
+1. **Messages** in the left sidebar.
+2. Click the thread.
+3. Type the response and send.
+4. Other team members see the thread; coordinate via the conversation's internal-note feature (visible to team only, not the recipient) to avoid duplicate replies.
+
+### Adding a new team member
+
+1. Sign in as admin → **Settings** → **Members** → **Invite member**.
+2. Enter their email and assign a role (typically Member).
+3. They accept the invite and complete login setup.
+4. Walk them through Inbox and Messages so they know where things land.
+
+### Removing a departed team member
+
+1. **Settings** → **Members** → click the departing member → **Remove**.
+2. Any threads they were the most-recent replier on are now "owned" by the team generally; check Inbox for dangling threads and reassign or close.
+
+### Configuring call routing and business hours
+
+1. **Settings** → **Phone numbers** → click the RLadies+ number → **Hours and routing**.
+2. Define business hours (e.g., weekdays 9am-5pm Pacific) and what happens outside them (typically straight to voicemail with a greeting).
+3. Within business hours, decide whether all members ring simultaneously (loud), only one member rings (quiet but reliant on that one person), or nobody rings and calls go straight to voicemail (which is honestly fine for a volunteer org — voicemails get triaged within a working day).
+
+### Setting up the voicemail greeting
+
+1. **Settings** → **Phone numbers** → click the number → **Voicemail**.
+2. **Record** in the browser, or **Upload** a pre-recorded file.
+3. The greeting should identify RLadies+ and set expectation: "You've reached RLadies+. Leave a message and we'll get back to you within a few business days, or email us at info@rladies.org for a faster response." TODO: confirm whether `info@` is the right address to direct callers to, or whether it should be `accounts@` / `contact@`.
+
+### Configuring call filtering for spam
+
+1. **Settings** → **Phone numbers** → click the number → **Call filtering** (or similar).
+2. Enable spam-call blocking — OpenPhone uses a community-maintained database; most telemarketers get filtered before ringing.
+3. Optional: send unknown callers to voicemail to filter further (downside: some legitimate callers won't leave a message).
+
+## Recovery
+
+2FA recovery codes saved in 1Password are the first option.
+OpenPhone's account recovery falls back to the role mailbox for email verification — Workspace access remains the prerequisite.
+
+If the OpenPhone account itself is the blocker (port-out fraud, suspicious sign-in), contact OpenPhone support immediately from a separate trusted email and freeze the number.
+
+## Things to watch for
+
+- **Unanswered voicemails.** Even "just telemarketers" voicemails should be skimmed within a working week — occasionally a real opportunity hides among the noise. Build the habit of checking the Inbox at the same cadence as Slack DMs.
+- **Spam call volume.** US numbers attract robocalls; if the rate becomes disruptive, tighten the call filtering settings.
+- **Shared-inbox confusion.** Without a convention, two members may reply to the same SMS independently and confuse the recipient. Agree on "claim before you reply" or use OpenPhone's internal-notes feature to coordinate.
+- **Account billing notifications.** They land on the role mailbox; forward to finance for the monthly reconciliation.
+- **Port-out risk.** The phone number itself has value; an attacker who compromises a US carrier account can sometimes port the number elsewhere. The role-mailbox recovery email plus 2FA on the OpenPhone account are the controls; review them periodically.

--- a/content/global-team/nonprofit-administration/vcorp/index.en.md
+++ b/content/global-team/nonprofit-administration/vcorp/index.en.md
@@ -1,0 +1,99 @@
+---
+title: "VCorp (California compliance and filings)"
+linkTitle: "VCorp"
+weight: 10
+---
+
+Every annual Statement of Information, every Form 990 filing, every notice from the California Franchise Tax Board lands first with VCorp — who scan it, email it, and prepare the response for leadership to approve.
+The arrangement is what lets RLadies+ stay in good standing as a California nonprofit even though no leadership member has to physically open mail at a California address or remember when the next biennial filing is due.
+
+## What VCorp does for us
+
+VCorp Services ([vcorpservices.com](https://www.vcorpservices.com)) is the registered agent and compliance partner.
+Specifically:
+
+- **Registered agent service.** California law requires every corporation (including 501(c)(3) nonprofits) to designate an in-state agent for service of process. VCorp's California address is the official one for RLadies+, and any legal documents (subpoenas, regulatory notices, lawsuit service) arrive there first.
+- **Statement of Information filings.** California requires a biennial Statement of Information from nonprofits, listing officers and the principal address. VCorp tracks the deadline, drafts the filing, and submits to the Secretary of State after leadership review.
+- **Form 990 and IRS filings.** The annual Form 990 (or 990-EZ for smaller orgs) goes to the IRS. VCorp prepares the draft from financial data we provide; leadership reviews and approves; VCorp files.
+- **Franchise Tax Board correspondence.** California's FTB sends periodic notices — exemption renewals, address verifications, occasional questionnaires. VCorp surfaces them and recommends responses.
+- **Document forwarding.** Anything official that arrives at the registered-agent address gets scanned and emailed within a working day.
+
+## Plan and billing
+
+TODO: confirm the annual VCorp engagement cost and renewal month.
+The fee typically covers registered-agent service plus a set number of filings; additional filings or amendments may incur per-event fees.
+
+## Who has access
+
+- The VCorp customer portal admin login is in the [1Password]({{% relref "/global-team/infrastructure/1password" %}}) Shared vault.
+- VCorp correspondence arrives at the role mailbox, plus the named primary contact in the VCorp account (TODO: confirm who).
+- Leadership members with finance or compliance responsibilities should have their own VCorp portal logins; admin operations stay with the admin login.
+
+## Operational tasks
+
+### Signing in
+
+1. Open the VCorp portal — TODO: confirm exact URL (typically [vcorpservices.com](https://www.vcorpservices.com) → Client Login, or a direct portal subdomain).
+2. Sign in with credentials from 1Password.
+3. The dashboard shows pending filings, deadlines, and any forwarded documents awaiting acknowledgement.
+
+### Acknowledging a forwarded official notice
+
+When VCorp scans and forwards a piece of mail:
+
+1. Open the PDF from the email or from the portal's Documents tab.
+2. Share with the leadership Slack channel (TODO: confirm which — `#leadership`? `#finance`?) with a one-line summary of what it is and what it appears to need.
+3. Decide who actions it — VCorp can usually file the response on our behalf once we've decided the substance.
+4. Save the original to the compliance folder in the Workspace Shared Drive (see [Shared Drive]({{% relref "/global-team/infrastructure/google-workspace/shared-drive" %}})) for the audit trail.
+
+### Approving a Statement of Information draft
+
+The biennial Statement of Information arrives as an emailed draft from VCorp:
+
+1. Open the draft. Verify the listed officers match current leadership, the principal address is correct, and the agent information is accurate.
+2. If anything is wrong, reply to VCorp with the corrections.
+3. If correct, reply approving the filing.
+4. VCorp files with the Secretary of State and emails confirmation; save the confirmation to the Shared Drive.
+
+### Approving the annual Form 990
+
+Form 990 needs financial data we provide (from [Relay]({{% relref "/global-team/finance/relay" %}}), [Wise]({{% relref "/global-team/finance/wise" %}}), and [PayPal]({{% relref "/global-team/finance/paypal" %}}) exports):
+
+1. Provide VCorp the year's financial data — typically a year-end summary of income (donations by category, grants, in-kind), expenses by category, and balance sheet snapshots.
+2. VCorp drafts the Form 990 and emails a review copy.
+3. Leadership (typically the treasurer role or the named primary contact) walks the draft line-by-line and confirms accuracy.
+4. Approve; VCorp e-files with the IRS and emails the filing confirmation plus the public copy.
+5. The public Form 990 also gets published to the website (TODO: confirm the publication location).
+
+### Downloading the 501(c)(3) determination letter
+
+Donors, partners, and grant applications regularly ask for the IRS determination letter as proof of nonprofit status:
+
+1. Sign in to the VCorp portal → Documents tab.
+2. Find the most recent IRS determination letter (the original 501(c)(3) approval; should remain valid unless the org's exempt status has been re-evaluated).
+3. Download and share.
+
+A copy should also live in the Shared Drive's compliance folder for quick access without needing to sign in to VCorp.
+
+## Annual calendar
+
+TODO: confirm the dates that matter for RLadies+'s fiscal year. The typical California nonprofit calendar:
+
+- **January-April**: tax season; Form 990 due 4.5 months after fiscal year end (for a calendar-year nonprofit, due May 15)
+- **Biennial month (TODO: confirm RLadies+'s)**: Statement of Information due
+- **Annually (TODO: confirm month)**: California FTB exemption renewal
+- **Quarterly or as-needed**: any federal or state form changes; VCorp surfaces these
+
+Putting the deadlines in a shared calendar that leadership all see (rather than relying on VCorp's reminders) catches the case where a VCorp email gets missed.
+
+## Recovery
+
+If the role mailbox becomes unreachable, VCorp customer service can be contacted directly using the support phone number in the portal to re-route notices and trigger a portal-access reset.
+The recovery email itself remains the same role mailbox, though, so restoring Workspace access is the real first step — cross-link [Google Workspace admin recovery]({{% relref "/global-team/infrastructure/google-workspace/admin-console" %}}#troubleshooting).
+
+## Things to watch for
+
+- **Deadline emails.** Missing a Statement of Information triggers a $50-$250 penalty plus eventual loss of good standing; missing a Form 990 risks IRS revocation of 501(c)(3) status after three consecutive years of non-filing. Treat VCorp deadline notices as load-bearing.
+- **Annual fee renewals.** VCorp's annual renewal usually arrives 60-90 days before the term ends. Confirm the budget covers it and process payment from [Relay]({{% relref "/global-team/finance/relay" %}}).
+- **VCorp_files but we_decide.** VCorp drafts filings using information we provide; if leadership composition changes mid-cycle without VCorp being told, the next Statement of Information will list the wrong officers. Update VCorp at the time leadership rotates, not at filing time.
+- **State-of-California audit risk.** California occasionally audits nonprofit filings. Keep the Shared Drive compliance folder current; if an audit notice arrives, route it to VCorp immediately rather than attempting to respond directly.


### PR DESCRIPTION
## Summary

Adds a new section at `content/global-team/nonprofit-administration/` covering the three external services that handle RLadies+'s California-nonprofit corporate surface:

- **`_index.en.md`** — section framing: a remote-run California 501(c)(3) needs a registered agent, a US phone number, and a street address even though no leadership member lives in California.
- **`vcorp/`** — California compliance partner: registered agent, biennial Statement of Information, annual Form 990, FTB correspondence, document forwarding. Includes the typical annual calendar and the "VCorp files but we decide" framing.
- **`openphone/`** — shared US phone number: voicemail with transcription, team SMS inbox, business hours/routing, call filtering, shared-inbox conventions.
- **`anytime-mailbox/`** — Oakland virtual business address: weekly mail-triage cadence, the four per-item action paths (Open/Scan/Shred, Open/Scan/Hold, Forward, Shred), authorised-recipient list maintenance, service-of-process routing to VCorp.

All three services share the same continuity pattern: credentials in the 1Password Shared vault, recovery on these services flows through the shared leadership role mailbox. Workspace admin recovery remains the prerequisite, and that operational reality is flagged consistently across the pages without naming the specific mailbox.

Stacks on #207.

## Test plan

- [ ] Confirm `{{% relref %}}` links to 1Password, Google Workspace, finance, and the cross-page links within this section resolve after stacked merges
- [ ] Fill the TODO markers (VCorp customer ID, OpenPhone tier and member roster, AnytimeMailbox tier and whether to print the street address here, annual calendar deadlines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)