### PR TITLE
Document Jinx's Copilot content reviews

### DIFF
--- a/content/global-team/jinx/commands.en.md
+++ b/content/global-team/jinx/commands.en.md
@@ -31,27 +31,30 @@ These commands return the information directly. No GitHub issues are created.
 | `/jinx translate status`                    | Translation coverage across languages                       |
 | `/jinx translate validate [lang]`           | Check translation placeholders                              |
 | `/jinx chapter-health`                      | Check chapter activity health                               |
-| `/jinx validate-directory`                  | Validate directory entries in a PR                          |
 | `/jinx blog-check-links`                    | Check all blog URLs for broken links                        |
 
 ## Action commands
 
 These commands perform an action (create an issue, send an invite, post an announcement) and reply with a link to what was created.
 
-| Command                                 | What it does                                                  |
-| --------------------------------------- | ------------------------------------------------------------- |
-| `/jinx invite @user to <team>`          | Invite a user to the org and a team, creates onboarding issue |
-| `/jinx offboard @user from <team>`      | Start offboarding, creates tracking issue                     |
-| `/jinx chapter-setup <city> <country>`  | Create a chapter setup checklist issue                        |
-| `/jinx chapter-update <city> <country>` | Create a chapter update issue                                 |
-| `/jinx blog-add <url>`                  | Auto-create a blog entry from a URL                           |
-| `/jinx cfp add <conf> <deadline> <url>` | Track a new call for proposals                                |
-| `/jinx cfp recommend <conf> @speaker`   | Recommend a speaker for a conference                          |
-| `/jinx contributors update [repo]`      | Update the contributors list via PR                           |
-| `/jinx events sync`                     | Sync and publish the chapter event summary                    |
-| `/jinx announce <post-url>`             | Announce a blog post on social media                          |
-| `/jinx remind stale`                    | Nudge stale onboarding/offboarding issues, report links       |
-| `/jinx slack-invite <email>`            | Post a Slack invite request for an organiser to action        |
+| Command                                 | What it does                                                                     |
+| --------------------------------------- | -------------------------------------------------------------------------------- |
+| `/jinx invite @user to <team>`          | Invite a user to the org and a team, creates onboarding issue                    |
+| `/jinx offboard @user from <team>`      | Start offboarding, creates tracking issue                                        |
+| `/jinx chapter-setup <city> <country>`  | Create a chapter setup checklist issue                                           |
+| `/jinx chapter-update <city> <country>` | Create a chapter update issue                                                    |
+| `/jinx blog-add <url>`                  | Auto-create a blog entry from a URL                                              |
+| `/jinx cfp add <conf> <deadline> <url>` | Track a new call for proposals                                                   |
+| `/jinx cfp recommend <conf> @speaker`   | Recommend a speaker for a conference                                             |
+| `/jinx contributors update [repo]`      | Update the contributors list via PR                                              |
+| `/jinx events sync`                     | Sync and publish the chapter event summary                                       |
+| `/jinx announce <post-url>`             | Announce a blog post on social media                                             |
+| `/jinx remind stale`                    | Nudge stale onboarding/offboarding issues, report links                          |
+| `/jinx slack-invite <email>`            | Post a Slack invite request for an organiser to action                           |
+| `/jinx review <gate> <pr>`              | Summon a Copilot content review on a PR (gate: brand, blog, social, translation) |
+| `/jinx copilot-sync <owner/repo>`       | Sync the grimoire review gates into a repo's Copilot instructions (PR)           |
+
+The `review` and `copilot-sync` commands drive [Copilot content reviews]({{< relref "for-developers#copilot-content-reviews" >}}) -- a pre-human review gate that flags brand, blog, social, and translation issues but never approves, merges, or publishes.
 
 ## Slack-only commands
 

--- a/content/global-team/jinx/for-developers.en.md
+++ b/content/global-team/jinx/for-developers.en.md
@@ -130,6 +130,43 @@ The jinx repo runs several checks on pull requests:
 
 If Jinx is not yet installed on the repo, ping someone with org-admin access.
 
+## Copilot content reviews
+
+Jinx can hand a content review to **GitHub Copilot**, guided by the four review gates in [rladies/grimoire](https://github.com/rladies/grimoire) -- brand, blog, social, and translation.
+Grimoire is a set of Claude Agent Skills, and Copilot only reads its own instruction files, so Jinx bridges the two.
+Turning it on for a repo is two steps.
+
+1. **Sync the gates into the repo.** Run `/jinx copilot-sync <owner/repo>`. It opens a PR that adds `.github/copilot-instructions.md` and path-scoped `.github/instructions/*.instructions.md` so Copilot's review speaks the RLadies+ brand and voice. Re-run it whenever grimoire changes.
+2. **Wire the reusable workflow** so Copilot reviews every content PR. It needs `pull-requests: write` on top of the usual `contents: read` / `packages: read`:
+
+```yaml
+# .github/workflows/jinx-copilot-review.yml
+name: Copilot review
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+    paths:
+      - "content/**"
+permissions:
+  contents: read
+  packages: read
+  pull-requests: write
+jobs:
+  copilot-review:
+    uses: rladies/jinx/.github/workflows/reusable-copilot-review.yml@main
+    secrets: inherit
+```
+
+On demand, an organiser can also summon a review from Slack or a GitHub comment, naming the gate and the PR:
+
+```
+/jinx review blog rladies/rladies.github.io#42
+```
+
+Copilot posts its findings on the PR as a tiered Blockers / Warnings / Nits punch list.
+It is a _pre-human_ review gate -- it flags issues for a human to act on, and never approves, merges, or publishes.
+Copilot code review must be enabled on the org, and Jinx's GitHub App needs Pull Requests read & write (it already has this).
+
 ## The jinx R package
 
 The command logic lives in the [`jinx` R package](https://rladies.github.io/jinx/).


### PR DESCRIPTION
## Summary

Documents the new Copilot content-review feature in Jinx (shipped in [rladies/jinx#80](https://github.com/rladies/jinx/pull/80)) in the global-team Jinx section:

- **Commands** (`commands.en.md`) — adds `/jinx review <gate> <pr>` and `/jinx copilot-sync <owner/repo>` to the action-commands table, with a short pointer to the setup section.
- **For developers** (`for-developers.en.md`) — a "Copilot content reviews" section: the two-step setup (`/jinx copilot-sync` to land the instruction files, then the `reusable-copilot-review.yml` caller with its `pull-requests: write` requirement), the on-demand command, and the org-level prerequisites.

**Drive-by fix:** removed the `/jinx validate-directory` row — that command was removed from Jinx (the directory repo validates entries on push/PR), so it was stale.

English-only page; no translations affected. Cross-link uses the same `relref` pattern as the existing links in the section.

_Note: I couldn't run a full local `hugo build` — the `hugo-theme-relearn` submodule wouldn't clone in my environment — so I validated the markdown and confirmed the `relref` target heading exists; Netlify will do the authoritative build here._