### PR TITLE
docs(jinx): document the new Community Slack invite gateway

### DIFF
--- a/content/global-team/jinx/airtable-invites.en.md
+++ b/content/global-team/jinx/airtable-invites.en.md
@@ -151,9 +151,14 @@ Jinx counts redemptions and warns `#team-community-slack` as the count nears the
 The invite link belongs to the **RLadies+ Leadership account (`leadership@rladies.org`)**, on both sides.
 
 First, it _issues_ the link.
-In the community workspace: workspace menu → _Invite people_ → copy the shared invite link.
-Only a workspace Owner or Admin can create one.
-Slack doesn't record who created a shared link, so this half is a procedural rule, not something the system can verify.
+The invite-acceptance screen shows _who_ is inviting people to the workspace, so the link should come from an account new joiners recognise and trust — and the leadership account carries the most credibility.
+Creating an invite link also needs a workspace Owner or Admin, which leadership is.
+
+To generate the link in the community workspace: workspace menu → _Invite people_ → _Copy link_.
+After clicking _Copy link_ once, an _Edit link_ menu appears — open it and set the link to _Never expire_, so it doesn't lapse on its own.
+It still stops at its signup cap (usually 400), which is what Jinx tracks and warns about.
+
+Slack doesn't record who created a shared link, so keeping this with leadership is a procedural rule, not something the system can verify.
 
 Second, it _activates_ the link, from Slack:
 

--- a/content/global-team/jinx/airtable-invites.en.md
+++ b/content/global-team/jinx/airtable-invites.en.md
@@ -1,52 +1,169 @@
 ---
-title: "Airtable invite webhook"
-menuTitle: "Airtable invites"
+title: "Community Slack invites"
+menuTitle: "Slack invites"
 weight: 50
 ---
 
 <img src="/img/jinx/working.svg" alt="Jinx the witch's cat, working at a desk" width="140" align="right" style="margin: 0 0 1rem 1.5rem;">
 
-_Runs in: **Cloudflare Worker** ([`worker/src/airtable-invite.js`](https://github.com/rladies/jinx/blob/main/worker/src/airtable-invite.js)). No GitHub Actions, no R package._
+_Runs in: **Cloudflare Worker** ([`worker/src/invite-gateway.js`](https://github.com/rladies/jinx/blob/main/worker/src/invite-gateway.js)) plus two Airtable automations. No GitHub Actions, no R package._
 
-When someone fills the RLadies+ chapter sign-up form (an Airtable form), Airtable POSTs a webhook to the Cloudflare Worker.
-The worker validates the request, checks the source base is on a per-token allowlist, and posts an actionable message in `#new-invitee` with an **Invite** button.
-An organiser clicks the button, the worker invites the email to the community Slack workspace, and updates the Airtable record so it does not re-fire.
+Joining the RLadies+ Community Slack mostly runs itself.
+Someone fills in the Airtable join form, confirms their email, and Jinx sends them a personal invite link — no organiser has to press a button for the everyday case.
+The real Slack invite link never leaves the server: each applicant gets a masked, single-use link on `join.rladies.org` that quietly redirects to it.
 
-## The flow
+This replaces the old "form → button → an organiser clicks _Invite_" flow.
+
+## Architecture at a glance
+
+```mermaid
+flowchart TB
+    A([Applicant])
+
+    subgraph AT["Airtable"]
+      SUB["submissions"]
+      TRK["tracking"]
+      AV{{"send verify<br>email"}}
+      AI{{"send invite<br>email"}}
+    end
+
+    subgraph W["Jinx Worker · invite-gateway.js"]
+      START["POST /invite/start"]
+      VER["GET /verify/:token"]
+      RED["GET /j/:token"]
+      TJ["team_join event"]
+    end
+
+    KV[("INVITE_TOKENS KV<br>masked master link")]
+    TS{{"Turnstile<br>bot check"}}
+    S([Community Slack])
+    L([Leadership<br>/jinx invite-link])
+
+    A -->|1 submit form| SUB
+    SUB -->|new-submission automation| START
+    START -->|create row + verify token| TRK
+    TRK --> AV
+    AV -->|2 confirm your email| A
+    A -->|3 click verify| VER
+    VER -->|stamp verified · mint invite| TRK
+    TRK --> AI
+    AI -->|4 your invitation| A
+    A -->|5 click invite| RED
+    RED --> TS
+    TS -->|pass| KV
+    KV -->|302 redirect| S
+    A -->|6 join| S
+    S -->|team_join| TJ
+    TJ -->|stamp Joined on| TRK
+    L -.->|rotate link| KV
+
+    style W fill:#562457,color:#fff
+    style KV fill:#883889,color:#fff
+```
+
+The short version: the form feeds Airtable, Jinx mints per-person tokens and emails them, and the one link that actually matters — the real Slack invite — stays hidden in Cloudflare KV, where only Jinx and the leadership rotation command can reach it.
+
+## The flow, step by step
 
 ```mermaid
 sequenceDiagram
     autonumber
+    participant A as Applicant
     participant F as Airtable form
-    participant AT as Airtable webhook
-    participant W as Cloudflare Worker
-    participant Org as Organiser in Slack
-    F->>AT: form submission
-    AT->>W: POST /airtable/webhook<br>(secret + record id)
-    W->>W: verify secret +<br>base allowlist
-    W->>Org: post Invite button<br>in #new-invitee
-    Org->>W: click Invite
-    W->>W: admin.users.invite +<br>mark record processed
-    W->>Org: button updates to "Invited ✓"
+    participant W as Jinx Worker
+    participant AT as Airtable · tracking
+    participant S as Community Slack
+    A->>F: submit join form
+    F->>W: POST /invite/start (shared secret)
+    W->>AT: create tracking row + Verify link
+    AT-->>A: "confirm your email" email
+    A->>W: click join.rladies.org/verify/…
+    W->>AT: stamp "Email verified on"
+    W->>W: guards (already a member? disposable domain?)
+    W->>AT: mint invite, write Invite link
+    AT-->>A: invitation email
+    A->>W: click join.rladies.org/j/…
+    W-->>A: Turnstile check, then 302 to the masked link
+    A->>S: join the workspace
+    S->>W: team_join event
+    W->>AT: stamp "Joined on"
 ```
 
-## Why a button and not an auto-invite
+## The masked invite link
 
-Auto-inviting from a public form would be a spam risk -- anyone could fill the form with any email.
-The two-step "form → button → human click" pattern gives a human the chance to skim the chapter and email before pulling the trigger, without making the organiser do any actual data entry.
+The real Slack invite link — the "master" link — lives _only_ in Cloudflare KV, at key `config:master_invite_link`.
+It is never emailed, never written to Airtable, and never committed to the repo.
 
-## Adding a new Airtable base
+Each applicant gets a per-person, expiring, limited-use link on `join.rladies.org` instead:
 
-The webhook validates the source base against the per-token allowlist served by [`worker/src/airtable-meta.js`](https://github.com/rladies/jinx/blob/main/worker/src/airtable-meta.js), which calls the Airtable Meta API with the `AIRTABLE_PAT` worker secret.
-To accept invites from a new base:
+- **`/verify/<token>`** proves they own the email (double opt-in) before any invite is minted.
+- **`/j/<token>`** redeems the invite — it runs an optional bot check, then `302`-redirects to the masked master link.
 
-1. Grant the existing Airtable PAT access to the new base in Airtable's PAT settings.
-2. Configure the form's webhook action to POST to `https://rladies-jinx.workers.dev/airtable/webhook` with the shared `AIRTABLE_WEBHOOK_SECRET` in the `x-airtable-secret` header.
-3. Include `record_id`, `base_id`, `table_id`, and `email` in the payload.
+Each link is single-use-ish (72 hours, three opens), so a forwarded one is close to useless.
+And because the real link sits behind the worker, nobody can mass-forward it, and rotating it is a one-liner that breaks nothing.
 
-The worker will pick the new base up the next time the Meta API allowlist refreshes -- no worker redeploy needed.
+## Two layers keep bots out
 
-## The matchback to Slack
+Double opt-in comes first.
+No invite is minted until the applicant clicks the verify link sent to their address, which on its own kills typos, other people's emails, and most bots.
 
-When someone signs up via the form and later joins the community Slack workspace, Jinx tries to match their Slack email to a pending Airtable record.
-If it finds one, the [welcome DM]({{< relref "ask-jinx#welcome-on-join" >}}) notes the match ("I matched you up with your RLadies+ chapter sign-up -- welcome aboard!") and the worker clears the pending link so it does not re-fire.
+Then come the guards.
+Before auto-inviting, Jinx skips anyone already in the workspace (`users.lookupByEmail`) and holds requests from disposable-email domains for a human to look at.
+Held requests post an alert to `#team-community-slack`; everything clean is invited automatically.
+
+Cloudflare Turnstile is the last wall.
+If the `TURNSTILE_*` keys are set, `/j/<token>` shows a quick, usually-invisible bot check right before the redirect.
+
+## The two Airtable tables
+
+The join form is backed by two linked tables:
+
+- **`submissions`** — the form's landing zone: name, email, the agreement checkboxes.
+- **`tracking`** — one row per invite attempt, linked back to a submission.
+
+Jinx walks each `tracking` row through the funnel:
+
+| Column              | Set when                             |
+| ------------------- | ------------------------------------ |
+| `Verify link`       | the row is created                   |
+| `Email verified on` | the applicant clicks the verify link |
+| `Invite link`       | the invite is auto-minted            |
+| `Invite sent on`    | the invitation email goes out        |
+| `Link clicked on`   | the invite link is opened            |
+| `Joined on`         | the applicant actually joins Slack   |
+
+Two Airtable automations send the emails — one when `Verify link` is written, one when `Invite link` is written.
+Jinx does the logic; Airtable does the sending.
+
+## Knowing when someone actually joined
+
+Clicking an invite link is not the same as joining.
+So when someone does join, Slack fires a `team_join` event, Jinx matches their email to a `tracking` row, and stamps `Joined on`.
+The result is a real funnel — requested, verified, invited, clicked, joined — rather than a guess.
+
+## The invite link's budget
+
+A Slack shared invite link is finite — usually 400 signups.
+Jinx counts redemptions and warns `#team-community-slack` as the count nears the cap, so someone can swap in a fresh link before it runs dry.
+
+## Rotating the link
+
+The invite link belongs to the **RLadies+ Leadership account (`leadership@rladies.org`)**, on both sides.
+
+First, it _issues_ the link.
+In the community workspace: workspace menu → _Invite people_ → copy the shared invite link.
+Only a workspace Owner or Admin can create one.
+Slack doesn't record who created a shared link, so this half is a procedural rule, not something the system can verify.
+
+Second, it _activates_ the link, from Slack:
+
+```
+/jinx invite-link https://join.slack.com/t/rladies-community/shared_invite/zt-NEW…
+→ ✅ Invite link updated — budget reset to 0/400.
+```
+
+The command is locked to `leadership@rladies.org` — Jinx checks the caller's verified email and turns everyone else away.
+Run it with no URL to see current usage (`137/400`) without exposing the link.
+Any invites already emailed re-point to the new link on their own.
+
+See [Commands]({{< relref "commands" >}}) for the command itself, and [Ask Jinx]({{< relref "ask-jinx#welcome-on-join" >}}) for the welcome DM new members get when they land.

--- a/content/global-team/jinx/commands.en.md
+++ b/content/global-team/jinx/commands.en.md
@@ -55,7 +55,7 @@ These commands perform an action (create an issue, send an invite, post an annou
 
 ## Slack-only commands
 
-These four commands never leave the Cloudflare Worker -- they hit the Slack Web API directly, so they reply in seconds without needing a GitHub Actions run.
+These commands never leave the Cloudflare Worker -- they hit the Slack Web API directly, so they reply in seconds without needing a GitHub Actions run.
 They exist only on Slack; running them in a GitHub comment will not do anything.
 
 | Command                            | What it does                                                        |
@@ -64,5 +64,8 @@ They exist only on Slack; running them in a GitHub comment will not do anything.
 | `/jinx pair @alice @bob [message]` | Open a group DM with mentioned users (up to 7)                      |
 | `/jinx remind-me <when> \| <what>` | Set a personal Slack reminder for yourself                          |
 | `/jinx feedback [days]`            | Show reaction signal on Jinx's recent answers                       |
+| `/jinx questions [days]`           | _(Global Team)_ What folks asked, the gaps, and 👎'd replies        |
+| `/jinx shorten <url> [slug]`       | _(Organisers)_ Create a `l.rladies.org` short link                  |
+| `/jinx invite-link [url] [cap]`    | _(Leadership)_ Show, or rotate, the Community Slack invite link     |
 
 For how slash commands actually flow through the worker and GitHub Actions, see [Slash commands]({{< relref "slash-commands" >}}).

--- a/content/global-team/jinx/slash-commands.en.md
+++ b/content/global-team/jinx/slash-commands.en.md
@@ -6,7 +6,7 @@ weight: 20
 
 <img src="/img/jinx/box_task.svg" alt="Jinx the witch's cat, carrying a box" width="140" align="right" style="margin: 0 0 1rem 1.5rem;">
 
-_Runs in: **Cloudflare Worker** (Slack slash entry) → **GitHub Actions** with the `jinx-bot` container (most commands) or **Worker only** ([the four local commands]({{< relref "commands#slack-only-commands" >}}))._
+_Runs in: **Cloudflare Worker** (Slack slash entry) → **GitHub Actions** with the `jinx-bot` container (most commands) or **Worker only** ([the local commands]({{< relref "commands#slack-only-commands" >}}))._
 
 A `/jinx ...` invocation has two front doors: GitHub issue comments and Slack slash commands.
 Both end up running the same R package logic; the only difference is which event triggers it and where the answer is posted.
@@ -44,7 +44,7 @@ Workspace-specific behaviour (welcome message, allowed commands) is driven by co
 
 **2. The Cloudflare Worker.** A small JavaScript function at `rladies-jinx.workers.dev` receives slash commands.
 It verifies the Slack request signature, checks the workspace is on the allowlist, immediately responds with a friendly quip so the user is not left waiting, and either handles the command itself or dispatches it to GitHub.
-`/jinx help`, `/jinx setup-channel`, `/jinx pair`, `/jinx remind-me`, and `/jinx feedback` are handled entirely in the worker (no GitHub Actions involved).
+`/jinx help`, `/jinx setup-channel`, `/jinx pair`, `/jinx remind-me`, `/jinx feedback`, `/jinx questions`, `/jinx shorten`, and `/jinx invite-link` are handled entirely in the worker (no GitHub Actions involved).
 Everything else is forwarded to GitHub Actions via `repository_dispatch`.
 The worker mints its own Jinx GitHub App installation token -- no personal access tokens involved.
 


### PR DESCRIPTION
## Summary
Updates the guide's Jinx docs for the invite system shipped in [rladies/jinx#120](https://github.com/rladies/jinx/pull/120)–#122.

- **`airtable-invites` page rewritten** for the masked-invite gateway — double opt-in, the `submissions`/`tracking` tables and their funnel columns, guards + Cloudflare Turnstile, `team_join` join-detection, the finite-budget alerting, and rotation via `/jinx invite-link`. Replaces the old "form → button → organiser clicks Invite" description.
- **Architecture flowchart** added up top (Mermaid) for the at-a-glance view, alongside a refreshed step-by-step sequence diagram.
- **`/jinx invite-link`** (leadership-only) added to the command list; the worker-local command list refreshed (it still listed "four" — now eight).

Written in the neutral technical/house voice (not a personal register), one sentence per line.

## Test plan
- `hugo` build succeeds; the page renders with the flowchart and command. The only warnings are the repo-wide pre-existing `relref`-anchor notices (present on every Jinx page, including before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)