### PR TITLE
docs(community): Weekly R Challenge page (draft — hold until live)

### DIFF
--- a/content/community/challenge/index.en.md
+++ b/content/community/challenge/index.en.md
@@ -1,0 +1,50 @@
+---
+title: "Weekly R Challenge"
+menuTitle: "Weekly R Challenge"
+weight: 60
+aliases:
+  - /comm/challenge/
+---
+
+Each week, a small R challenge is posted to the RLadies+ community Slack <U+2014> a
+low-stakes, friendly way to write a bit of R, stretch your skills, and learn
+from how other people solve it.
+
+Every challenge is tagged with a difficulty, so you can pick your level:
+
+- <U+0001F7E2> **Novice** <U+2014> beginner-friendly, one concept
+- <U+0001F7E1> **Adept** <U+2014> comfortable with R, combine a few ideas
+- <U+0001F534> **Oracle** <U+2014> experienced, non-trivial logic or idioms
+
+## Joining in
+
+Have a go! Share your solution in the thread, and react <U+2705> if you cracked it or
+<U+0001F914> if you're still stewing. There's no leaderboard and no wrong way to take
+part <U+2014> half the fun is seeing the different approaches people come up with.
+
+## Suggest your own challenge
+
+Got a puzzle you'd love others to try? Challenges are community-driven, so you
+can submit your own. Head to the
+[`cauldron` repository](https://github.com/rladies/cauldron){target="_blank"},
+open the challenge form, and follow the
+[guidelines](https://github.com/rladies/cauldron/blob/main/CONTRIBUTING.md){target="_blank"} <U+2014>
+they cover what's in scope and how difficulty is decided.
+
+## For organisers: help review
+
+Before any challenge reaches the community, an organiser gives it a quick
+once-over <U+2014> checking it's clear, fair, and correctly rated. It's light work,
+and a lovely way to support the community.
+
+Challenges waiting for review appear as
+[`status: proposed` issues in `cauldron`](https://github.com/rladies/cauldron/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+proposed%22){target="_blank"}.
+If you'd like to help triage them <U+2014> or help shape the challenge guidelines
+themselves <U+2014> say hello in the community Slack or open an issue in the repo.
+
+---
+
+_The weekly challenge is drafted, verified, and posted with the help of
+[Jinx](https://github.com/rladies/jinx){target="_blank"}, the RLadies+
+automation familiar. Every challenge still gets a human review before it goes
+out._


### PR DESCRIPTION
## Summary

Adds a **Weekly R Challenge** page under Community Programmes.

The weekly R challenge is a low-stakes, friendly way for the community to write a bit of R and learn from each other — a difficulty-tagged puzzle posted to the community Slack each week (🟢 Novice / 🟡 Adept / 🔴 Oracle). This page covers:

- what it is and how to join in (solve, react, share in-thread),
- how to **submit your own** challenge (challenges are community-driven),
- how **organisers can help review** challenges before they're posted, and help shape the guidelines.

It deliberately **points to [`rladies/cauldron`](https://github.com/rladies/cauldron)** — the repo that holds the challenges, the submission form, and the full guidelines/rubric — rather than duplicating that content here, so there's a single source of truth.

## ⛔ Draft — hold until the feature is live

This is intentionally a **draft**. Please don't merge yet: the guide is the authoritative organiser reference, and it shouldn't describe a flow that isn't running.

Merge once:

- [ ] `rladies/cauldron` is populated and accepting submissions, and
- [ ] Jinx's draft-to-issue and post-to-Slack crons are live (jinx slices 2 & 3).

At that point the links here all resolve to something real.

## Notes

- **English only** for now; the Spanish translation can follow via the usual translation flow (like other sub-pages, e.g. `rcwg`, this page is EN-only to start).
- A Netlify deploy preview will show the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
